### PR TITLE
Error refacto

### DIFF
--- a/src/assets/localizables/fr.json
+++ b/src/assets/localizables/fr.json
@@ -10,6 +10,7 @@
         "unauthorized": "Vous ne disposez pas des autorisations suffisantes pour effectuer cette demande.\n(code 401)",
         "forbidden": "Cette demande n'est pas autorisée.\n(code 403)",
         "not_found": "La ressource que vous essayez de récupérer ne semble pas exister.\n(code 404)",
+        "parsing": "Le format de la réponse n'est pas lisible. Veuillez réessayer ultérieurement. ",
         "generic": "Une erreur est survenue"
       },
       "error_reload": "Rechargez la page",

--- a/src/screens/actions/ActionsScreen.tsx
+++ b/src/screens/actions/ActionsScreen.tsx
@@ -5,7 +5,6 @@ import { Action } from '../../core/entities/Action'
 import ActionsRepository from '../../data/ActionsRepository'
 import { Colors, Spacing, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { ActionRow } from './ActionRow'
 import { ActionRowViewModel } from './ActionRowViewModel'
@@ -14,6 +13,7 @@ import { useTheme } from '../../themes'
 import { GetPhoningStateInteractor } from '../../core/interactor/GetPhoningStateInteractor'
 import { PhoningState } from '../../core/entities/PhoningState'
 import { ActionsScreenProp } from '../../navigation'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const ActionsScreen = ({ navigation }: ActionsScreenProp) => {
   const [statefulState, setStatefulState] = useState<
@@ -38,9 +38,7 @@ const ActionsScreen = ({ navigation }: ActionsScreenProp) => {
         })
         .catch((error) => {
           setStatefulState(
-            new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () =>
-              fetch(enablePhoning),
-            ),
+            ViewStateUtils.networkError(error, () => fetch(enablePhoning)),
           )
         })
     },

--- a/src/screens/authentication/ZipCodeConfirmation.tsx
+++ b/src/screens/authentication/ZipCodeConfirmation.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState } from 'react'
-import { Alert, Image, StyleSheet, Text } from 'react-native'
+import { Image, StyleSheet, Text } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import { Department } from '../../core/entities/Department'
 import { AnonymousLoginInteractor } from '../../core/interactor/AnonymousLoginInteractor'
@@ -8,6 +8,7 @@ import { ZipCodeConfirmationScreenProps } from '../../navigation'
 import { Colors, Spacing, Typography } from '../../styles'
 import { useTheme } from '../../themes'
 import i18n from '../../utils/i18n'
+import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
 import { GenericErrorMapper } from '../shared/ErrorMapper'
 import LoadingOverlay from '../shared/LoadingOverlay'
@@ -25,29 +26,11 @@ const ZipCodeConfirmationContent: FunctionComponent<ContentProps> = ({
   const [isLoading, setIsLoading] = useState(false)
   const { theme } = useTheme()
 
-  const displayError = (error: string) => {
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.error_retry'),
-          onPress: authenticate,
-        },
-        {
-          text: i18n.t('common.cancel'),
-          style: 'cancel',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   const authenticate = () => {
     setIsLoading(true)
     new AnonymousLoginInteractor()
       .login(zipCode)
-      .catch((error) => displayError(GenericErrorMapper.mapErrorMessage(error)))
+      .catch((error) => AlertUtils.showNetworkAlert(error, authenticate))
       .finally(() => setIsLoading(false))
   }
 

--- a/src/screens/authentication/ZipCodeConfirmation.tsx
+++ b/src/screens/authentication/ZipCodeConfirmation.tsx
@@ -10,9 +10,9 @@ import { useTheme } from '../../themes'
 import i18n from '../../utils/i18n'
 import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import LoadingOverlay from '../shared/LoadingOverlay'
 import { StatefulView, ViewState } from '../shared/StatefulView'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 type ContentProps = Readonly<{
   department: string
@@ -71,13 +71,10 @@ const ZipCodeConfirmationScreen = ({
         })
         .catch((error) => {
           setStatefulState(
-            new ViewState.Error(
-              GenericErrorMapper.mapErrorMessage(error),
-              () => {
-                setStatefulState(new ViewState.Loading())
-                fetchData()
-              },
-            ),
+            ViewStateUtils.networkError(error, () => {
+              setStatefulState(new ViewState.Loading())
+              fetchData()
+            }),
           )
         })
     }

--- a/src/screens/doorToDoor/DoorToDoorCharterModal.tsx
+++ b/src/screens/doorToDoor/DoorToDoorCharterModal.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react'
-import { Alert, ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import Markdown from 'react-native-markdown-display'
 import SafeAreaView from 'react-native-safe-area-view'
 import DoorToDoorRepository from '../../data/DoorToDoorRepository'
 import { Colors, Spacing, Styles, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
+import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { NavigationHeaderButton } from '../shared/NavigationHeaderButton'
 
 type Props = {
@@ -21,22 +21,8 @@ const DoorToDoorCharterModal: FC<Props> = (props) => {
       .acceptDoorToDoorCharter()
       .then(() => props.onAcceptCharter())
       .catch((error: Error) => {
-        displayError(GenericErrorMapper.mapErrorMessage(error))
+        AlertUtils.showNetworkAlert(error, acceptCharter)
       })
-  }
-
-  const displayError = (error: string) => {
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.ok'),
-          style: 'default',
-        },
-      ],
-      { cancelable: false },
-    )
   }
 
   const markdownStyle = { body: styles.chartContainer }

--- a/src/screens/events/EventDetailsScreen.tsx
+++ b/src/screens/events/EventDetailsScreen.tsx
@@ -31,12 +31,12 @@ import CardView from '../shared/CardView'
 import PollRow from '../polls/PollRow'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import EventRepository from '../../data/EventRepository'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { EventDetailsViewModelMapper } from './EventDetailsViewModelMapper'
 import LoadingOverlay from '../shared/LoadingOverlay'
 import HTML from 'react-native-render-html'
 import { ForbiddenError } from '../../core/errors'
 import { AlertUtils } from '../shared/AlertUtils'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const EventDetailsContent = (
   viewModel: EventDetailsViewModel,
@@ -309,11 +309,7 @@ const EventDetailsScreen: FC<EventDetailsScreenProps> = ({
         setStatefulState(new ViewState.Content(viewModel))
       })
       .catch((error) => {
-        setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
-            refetchData()
-          }),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, refetchData))
       })
   }
 

--- a/src/screens/events/EventListScreen.tsx
+++ b/src/screens/events/EventListScreen.tsx
@@ -16,7 +16,6 @@ import { Spacing, Typography } from '../../styles'
 import { useTheme } from '../../themes'
 import { DateProvider } from '../../utils/DateProvider'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import LoaderView from '../shared/LoaderView'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import EventGridItem from './EventGridItem'
@@ -29,6 +28,7 @@ import {
 import { EventSectionViewModelMapper } from './EventSectionViewModelMapper'
 import { GetMainEventsInteractor } from '../../core/interactor/GetMainEventsInteractor'
 import { useFocusEffect } from '@react-navigation/core'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 type Props = Readonly<{
   eventFilter: EventFilter
@@ -70,7 +70,7 @@ const EventListScreen: FC<Props> = (props) => {
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             loadFirstPage()
           }),

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -15,7 +15,6 @@ import SafeAreaView from 'react-native-safe-area-view'
 import { HomeScreenProps, Screen } from '../../navigation'
 import { Colors } from '../../styles'
 import { useTheme } from '../../themes'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import HomeHeader from './HomeHeader'
 import HomePollRowContainer from './HomePollRowContainer'
@@ -41,6 +40,7 @@ import { HomeEventRowContainer } from './events/HomeEventRowContainer'
 import { ProfileButton } from '../shared/NavigationHeaderButton'
 import { HomeRetaliationRowContainer } from './retaliation/HomeRetaliationRowContainer'
 import { RetaliationService } from '../../data/RetaliationService'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const HomeScreen: FunctionComponent<HomeScreenProps> = ({ navigation }) => {
   const { theme, setTheme } = useTheme()
@@ -101,13 +101,10 @@ const HomeScreen: FunctionComponent<HomeScreenProps> = ({ navigation }) => {
             return
           }
           setStatefulState(
-            new ViewState.Error(
-              GenericErrorMapper.mapErrorMessage(error),
-              () => {
-                setStatefulState(new ViewState.Loading())
-                fetchData()
-              },
-            ),
+            ViewStateUtils.networkError(error, () => {
+              setStatefulState(new ViewState.Loading())
+              fetchData()
+            }),
           )
         })
         .finally(() => {

--- a/src/screens/news/NewsScreen.tsx
+++ b/src/screens/news/NewsScreen.tsx
@@ -12,10 +12,10 @@ import NewsRepository from '../../data/NewsRepository'
 import ProfileRepository from '../../data/ProfileRepository'
 import { Colors, Spacing } from '../../styles'
 import { useTheme } from '../../themes'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { ExternalLink } from '../shared/ExternalLink'
 import LoaderView from '../shared/LoaderView'
 import { StatefulView, ViewState } from '../shared/StatefulView'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 import NewsContentViewModel from './NewsContentViewModel'
 import { NewsContentViewModelMapper } from './NewsContentViewModelMapper'
 import NewsRow from './NewsRow'
@@ -46,7 +46,7 @@ const NewsScreen = () => {
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             loadFirstPage()
           }),

--- a/src/screens/personalInformation/PersonalInformationScreen.tsx
+++ b/src/screens/personalInformation/PersonalInformationScreen.tsx
@@ -6,7 +6,6 @@ import {
   TextInput,
   ScrollView,
   TouchableOpacity,
-  Alert,
 } from 'react-native'
 import { Colors, Spacing, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
@@ -38,6 +37,7 @@ import { useThemedStyles } from '../../themes'
 import Theme from '../../themes/Theme'
 import { PersonalInformationsForm } from '../../core/entities/PersonalInformationsForm'
 import { PersonalInformationsFormMapper } from '../../core/mapper/PersonalInformationsFormMapper'
+import { AlertUtils } from '../shared/AlertUtils'
 
 type ContentProps = Readonly<{
   profileUuid: string
@@ -74,24 +74,6 @@ const PersonalInformationScreenContent: FC<ContentProps> = ({
   }
 
   const submit = useCallback(() => {
-    const displayError = (error: string) => {
-      console.log('Displaying error ', error)
-      Alert.alert(
-        i18n.t('common.error_title'),
-        error,
-        [
-          {
-            text: i18n.t('common.error_retry'),
-            onPress: submit,
-          },
-          {
-            text: i18n.t('common.cancel'),
-            style: 'cancel',
-          },
-        ],
-        { cancelable: false },
-      )
-    }
     setIsLoading(true)
     setErrors([])
     ProfileRepository.getInstance()
@@ -101,7 +83,7 @@ const PersonalInformationScreenContent: FC<ContentProps> = ({
         if (error instanceof ProfileFormError) {
           setErrors(error.violations)
         } else {
-          displayError(GenericErrorMapper.mapErrorMessage(error))
+          AlertUtils.showNetworkAlert(error, submit)
         }
       })
       .finally(() => setIsLoading(false))

--- a/src/screens/personalInformation/PersonalInformationScreen.tsx
+++ b/src/screens/personalInformation/PersonalInformationScreen.tsx
@@ -27,7 +27,6 @@ import {
   FormViolation,
 } from '../../core/entities/DetailedProfile'
 import ProfileRepository from '../../data/ProfileRepository'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { Gender } from '../../core/entities/UserProfile'
 import PhoneNumberInput from './PhoneNumberInput'
 import LoadingOverlay from '../shared/LoadingOverlay'
@@ -38,6 +37,7 @@ import Theme from '../../themes/Theme'
 import { PersonalInformationsForm } from '../../core/entities/PersonalInformationsForm'
 import { PersonalInformationsFormMapper } from '../../core/mapper/PersonalInformationsFormMapper'
 import { AlertUtils } from '../shared/AlertUtils'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 type ContentProps = Readonly<{
   profileUuid: string
@@ -302,13 +302,10 @@ const PersonalInformationScreen = ({
         })
         .catch((error) => {
           setStatefulState(
-            new ViewState.Error(
-              GenericErrorMapper.mapErrorMessage(error),
-              () => {
-                setStatefulState(new ViewState.Loading())
-                fetchData()
-              },
-            ),
+            ViewStateUtils.networkError(error, () => {
+              setStatefulState(new ViewState.Loading())
+              fetchData()
+            }),
           )
         })
     }

--- a/src/screens/personalInformation/centerinterest/CenterOfInterestScreen.tsx
+++ b/src/screens/personalInformation/centerinterest/CenterOfInterestScreen.tsx
@@ -16,7 +16,6 @@ import { CentersOfInterestScreenProps } from '../../../navigation'
 import { Colors, Spacing, Styles, Typography } from '../../../styles'
 import i18n from '../../../utils/i18n'
 import { PrimaryButton } from '../../shared/Buttons'
-import { GenericErrorMapper } from '../../shared/ErrorMapper'
 import LoadingOverlay from '../../shared/LoadingOverlay'
 import { StatefulView, ViewState } from '../../shared/StatefulView'
 import { CentersOfInterestViewModelMapper } from './CentersOfInterestViewModelMapper'
@@ -24,6 +23,7 @@ import SelectableIconLabelView, {
   SelectableIconLabelViewModel,
 } from '../../shared/SelectableIconLabelView'
 import { AlertUtils } from '../../shared/AlertUtils'
+import { ViewStateUtils } from '../../shared/ViewStateUtils'
 
 const CenterOfInterestContent = (
   content: CentersOfInterestInteractorResult,
@@ -109,7 +109,7 @@ const CenterOfInterestScreen = ({
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             fetchData()
           }),

--- a/src/screens/personalInformation/centerinterest/CenterOfInterestScreen.tsx
+++ b/src/screens/personalInformation/centerinterest/CenterOfInterestScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import {
-  Alert,
   FlatList,
   ListRenderItemInfo,
   StyleSheet,
@@ -24,6 +23,7 @@ import { CentersOfInterestViewModelMapper } from './CentersOfInterestViewModelMa
 import SelectableIconLabelView, {
   SelectableIconLabelViewModel,
 } from '../../shared/SelectableIconLabelView'
+import { AlertUtils } from '../../shared/AlertUtils'
 
 const CenterOfInterestContent = (
   content: CentersOfInterestInteractorResult,
@@ -43,23 +43,6 @@ const CenterOfInterestContent = (
   }
 
   const submit = useCallback(() => {
-    const displayError = (error: string) => {
-      Alert.alert(
-        i18n.t('common.error_title'),
-        error,
-        [
-          {
-            text: i18n.t('common.error_retry'),
-            onPress: submit,
-          },
-          {
-            text: i18n.t('common.cancel'),
-            style: 'cancel',
-          },
-        ],
-        { cancelable: false },
-      )
-    }
     setIsLoading(true)
     PersonalInformationRepository.getInstance()
       .updateCentersOfInterest(
@@ -69,7 +52,7 @@ const CenterOfInterestContent = (
           .map((interest) => interest.code),
       )
       .then(onSumitSuccessful)
-      .catch((error) => displayError(GenericErrorMapper.mapErrorMessage(error)))
+      .catch((error) => AlertUtils.showNetworkAlert(error, submit))
       .finally(() => setIsLoading(false))
   }, [content, viewModel, onSumitSuccessful])
 

--- a/src/screens/personalInformation/notifications/NotificationsScreen.tsx
+++ b/src/screens/personalInformation/notifications/NotificationsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import {
-  Alert,
   SectionList,
   SectionListRenderItemInfo,
   StyleSheet,
@@ -17,6 +16,7 @@ import PersonalInformationRepository from '../../../data/PersonalInformationRepo
 import { NotificationsScreenProps } from '../../../navigation'
 import { Colors, Spacing, Typography } from '../../../styles'
 import i18n from '../../../utils/i18n'
+import { AlertUtils } from '../../shared/AlertUtils'
 import { GenericErrorMapper } from '../../shared/ErrorMapper'
 import LoadingOverlay from '../../shared/LoadingOverlay'
 import { StatefulView, ViewState } from '../../shared/StatefulView'
@@ -36,20 +36,6 @@ const NotificationsContent = (
     content.notificationsEnabled,
   )
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const displayError = (error: string) => {
-    console.log('Displaying error ', error)
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.ok'),
-          style: 'default',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
   const onNotificationChanged = (id: string, isSelected: boolean) => {
     if (id === ID_PUSH) {
       setIsLoading(true)
@@ -57,7 +43,7 @@ const NotificationsContent = (
         .execute(category, isSelected)
         .then(() => refetchData())
         .catch((error) => {
-          displayError(GenericErrorMapper.mapErrorMessage(error))
+          AlertUtils.showNetworkAlert(error, undefined)
         })
         .finally(() => {
           setIsLoading(false)
@@ -81,7 +67,7 @@ const NotificationsContent = (
         .updateSubscriptions(content.userUuid, newSubscriptions)
         .then(() => refetchData())
         .catch((error) => {
-          displayError(GenericErrorMapper.mapErrorMessage(error))
+          AlertUtils.showNetworkAlert(error, undefined)
         })
         .finally(() => {
           setIsLoading(false)

--- a/src/screens/personalInformation/notifications/NotificationsScreen.tsx
+++ b/src/screens/personalInformation/notifications/NotificationsScreen.tsx
@@ -17,9 +17,9 @@ import { NotificationsScreenProps } from '../../../navigation'
 import { Colors, Spacing, Typography } from '../../../styles'
 import i18n from '../../../utils/i18n'
 import { AlertUtils } from '../../shared/AlertUtils'
-import { GenericErrorMapper } from '../../shared/ErrorMapper'
 import LoadingOverlay from '../../shared/LoadingOverlay'
 import { StatefulView, ViewState } from '../../shared/StatefulView'
+import { ViewStateUtils } from '../../shared/ViewStateUtils'
 import NotificationRowView from './NotificationRowView'
 import { ID_PUSH, NotificationRowViewModel } from './NotificationViewModel'
 import { NotificationViewModelMapper } from './NotificationViewModelMapper'
@@ -116,7 +116,7 @@ const NotificationsScreen = (props: NotificationsScreenProps) => {
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             fetchData()
           }),

--- a/src/screens/phoneCallStatusPicker/PhoneCallStatusPickerScreen.tsx
+++ b/src/screens/phoneCallStatusPicker/PhoneCallStatusPickerScreen.tsx
@@ -10,7 +10,6 @@ import {
   ListRenderItemInfo,
   FlatList,
   View,
-  Alert,
 } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import { PhoningSessionCallStatus } from '../../core/entities/PhoningSessionConfiguration'
@@ -21,6 +20,7 @@ import i18n from '../../utils/i18n'
 import { PhonePollDetailCallStatusViewModelMapper } from '../phonePollDetail/PhonePollDetailCallStatusViewModelMapper'
 import QuestionChoiceRow from '../pollDetail/QuestionChoiceRow'
 import { QuestionChoiceRowViewModel } from '../pollDetail/QuestionChoiceRowViewModel'
+import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
 import { GenericErrorMapper } from '../shared/ErrorMapper'
 import LoadingOverlay from '../shared/LoadingOverlay'
@@ -78,24 +78,6 @@ const PhoneCallStatusPickerScreen: FunctionComponent<PhoneCallStatusPickerScreen
     )
   }
 
-  const displayError = (error: string, statusCode: string) => {
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.error_retry'),
-          onPress: () => sendStatusCodeAndLeave(statusCode),
-        },
-        {
-          text: i18n.t('common.cancel'),
-          style: 'cancel',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   const sendStatusCodeAndLeave = (statusCode: string) => {
     setLoading(true)
     PhoningCampaignRepository.getInstance()
@@ -106,7 +88,9 @@ const PhoneCallStatusPickerScreen: FunctionComponent<PhoneCallStatusPickerScreen
         })
       })
       .catch((error) => {
-        displayError(GenericErrorMapper.mapErrorMessage(error), statusCode)
+        AlertUtils.showNetworkAlert(error, () =>
+          sendStatusCodeAndLeave(statusCode),
+        )
       })
       .finally(() => setLoading(true))
   }

--- a/src/screens/phoneCallStatusPicker/PhoneCallStatusPickerScreen.tsx
+++ b/src/screens/phoneCallStatusPicker/PhoneCallStatusPickerScreen.tsx
@@ -22,11 +22,11 @@ import QuestionChoiceRow from '../pollDetail/QuestionChoiceRow'
 import { QuestionChoiceRowViewModel } from '../pollDetail/QuestionChoiceRowViewModel'
 import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import LoadingOverlay from '../shared/LoadingOverlay'
 import { VerticalSpacer } from '../shared/Spacer'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { usePreventGoingBack } from '../shared/usePreventGoingBack.hook'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const PhoneCallStatusPickerScreen: FunctionComponent<PhoneCallStatusPickerScreenProps> = ({
   navigation,
@@ -48,11 +48,7 @@ const PhoneCallStatusPickerScreen: FunctionComponent<PhoneCallStatusPickerScreen
         setStatefulState(new ViewState.Content(callStatuses)),
       )
       .catch((error) => {
-        setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
-            fetchCallStatuses()
-          }),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetchCallStatuses))
       })
   }, [route.params.data.sessionId])
 

--- a/src/screens/phonePollDetail/PhonePollDetailScreen.tsx
+++ b/src/screens/phonePollDetail/PhonePollDetailScreen.tsx
@@ -7,7 +7,6 @@ import React, {
 import { View, StyleSheet } from 'react-native'
 
 import { StatefulView, ViewState } from '../shared/StatefulView'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { CloseButton } from '../shared/NavigationHeaderButton'
 import ModalOverlay from '../shared/ModalOverlay'
 import { useTheme } from '../../themes'
@@ -23,6 +22,7 @@ import {
   PhonePollDetailResources,
 } from '../../core/interactor/GetPhonePollDetailResourcesInteractor'
 import { AlertUtils } from '../shared/AlertUtils'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const PhonePollDetailScreen: FunctionComponent<PhonePollDetailScreenProps> = ({
   route,
@@ -69,12 +69,7 @@ const PhonePollDetailScreen: FunctionComponent<PhonePollDetailScreenProps> = ({
       })
       .catch((error) => {
         console.error(error)
-        setStatefulState(
-          new ViewState.Error(
-            GenericErrorMapper.mapErrorMessage(error),
-            fetchResources,
-          ),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetchResources))
       })
   }
 

--- a/src/screens/phonePollDetail/PhonePollDetailScreen.tsx
+++ b/src/screens/phonePollDetail/PhonePollDetailScreen.tsx
@@ -4,7 +4,7 @@ import React, {
   useLayoutEffect,
   useState,
 } from 'react'
-import { View, StyleSheet, Alert } from 'react-native'
+import { View, StyleSheet } from 'react-native'
 
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { GenericErrorMapper } from '../shared/ErrorMapper'
@@ -16,13 +16,13 @@ import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
 import PhonePollDetailScreenLoaded from './PhonePollDetailScreenLoaded'
 import PhonePollDetailInterruptionModalContent from './PhonePollDetailInterruptionModalContent'
 import LoadingOverlay from '../shared/LoadingOverlay'
-import i18n from '../../utils/i18n'
 import { usePreventGoingBack } from '../shared/usePreventGoingBack.hook'
 import { useBackHandler } from '../shared/useBackHandler.hook'
 import {
   GetPhonePollDetailResourcesInteractor,
   PhonePollDetailResources,
 } from '../../core/interactor/GetPhonePollDetailResourcesInteractor'
+import { AlertUtils } from '../shared/AlertUtils'
 
 const PhonePollDetailScreen: FunctionComponent<PhonePollDetailScreenProps> = ({
   route,
@@ -85,31 +85,15 @@ const PhonePollDetailScreen: FunctionComponent<PhonePollDetailScreenProps> = ({
     theme,
   ])
 
-  const displayError = (error: string, statusCode: string) => {
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.error_retry'),
-          onPress: () => sendInterruptionStatusAndLeave(statusCode),
-        },
-        {
-          text: i18n.t('common.cancel'),
-          style: 'cancel',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   const sendInterruptionStatusAndLeave = (statusCode: string) => {
     setLoading(true)
     PhoningCampaignRepository.getInstance()
       .updatePhoningSessionStatus(route.params.data.sessionId, statusCode)
       .then(() => navigation.pop())
       .catch((error) =>
-        displayError(GenericErrorMapper.mapErrorMessage(error), statusCode),
+        AlertUtils.showNetworkAlert(error, () =>
+          sendInterruptionStatusAndLeave(statusCode),
+        ),
       )
       .finally(() => setLoading(false))
   }

--- a/src/screens/phonePollDetail/PhonePollDetailScreenLoaded.tsx
+++ b/src/screens/phonePollDetail/PhonePollDetailScreenLoaded.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { StyleSheet, View, FlatList, Alert } from 'react-native'
+import { StyleSheet, View, FlatList } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import { Colors, Spacing } from '../../styles'
 import PollDetailNavigationButtons from '../pollDetail/PollDetailNavigationButtons'
@@ -26,9 +26,8 @@ import { CompoundPollDetailComponentProvider } from '../pollDetail/providers/Com
 import { PhonePollDetailSatisfactionComponentProvider } from './providers/PhonePollDetailSatisfactionComponentProvider'
 import { PhoningSatisfactionQuestion } from '../../core/entities/PhoningSessionConfiguration'
 import { PhonePollResult } from '../../core/entities/PhonePollResult'
-import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { SendPhonePollAnswersInteractor } from '../../core/interactor/SendPhonePollAnswersInteractor'
+import { AlertUtils } from '../shared/AlertUtils'
 
 type Props = Readonly<{
   poll: Poll
@@ -85,25 +84,6 @@ const PhonePollDetailScreenLoaded: FunctionComponent<Props> = ({
     })
   }, [currentStep])
 
-  const displayError = (error: string) => {
-    console.log('Displaying error ', error)
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.error_retry'),
-          onPress: postAnswers,
-        },
-        {
-          text: i18n.t('common.cancel'),
-          style: 'cancel',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   const postAnswers = () => {
     setIsLoading(true)
     new SendPhonePollAnswersInteractor()
@@ -115,7 +95,7 @@ const PhonePollDetailScreenLoaded: FunctionComponent<Props> = ({
         })
       })
       .catch((error) => {
-        displayError(GenericErrorMapper.mapErrorMessage(error))
+        AlertUtils.showNetworkAlert(error, postAnswers)
       })
       .finally(() => setIsLoading(false))
   }

--- a/src/screens/phoning/PhoningScreen.tsx
+++ b/src/screens/phoning/PhoningScreen.tsx
@@ -21,13 +21,13 @@ import PhoningTutorialRow from './tutorial/PhoningTutorialRow'
 import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
 import PhoningCallContactRow from './callContact/CallContactRow'
 import { PhoningCampaign } from '../../core/entities/PhoningCampaign'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import PhoningCampaignRow from './campaign/PhoningCampaignRow'
 import {
   PhoningCharterNotAccepted,
   PhoningCharterState,
 } from '../../core/entities/PhoningCharterState'
 import i18n from '../../utils/i18n'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 export interface PhoningResources {
   campaigns: PhoningCampaign[]
@@ -59,7 +59,7 @@ const PhoningScreen: FunctionComponent<PhoningScreenProp> = ({
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             fetchData()
           }),

--- a/src/screens/phoningCharter/PhoningCharterScreen.tsx
+++ b/src/screens/phoningCharter/PhoningCharterScreen.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent, useEffect } from 'react'
-import { Alert, ScrollView, StyleSheet, View } from 'react-native'
+import { ScrollView, StyleSheet, View } from 'react-native'
 import Markdown from 'react-native-markdown-display'
 import SafeAreaView from 'react-native-safe-area-view'
 import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
 import { PhoningCharterScreenProp, Screen } from '../../navigation'
 import { Colors, Spacing, Styles } from '../../styles'
 import i18n from '../../utils/i18n'
+import { AlertUtils } from '../shared/AlertUtils'
 import { PrimaryButton } from '../shared/Buttons'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 
 const PhoningCharterScreen: FunctionComponent<PhoningCharterScreenProp> = ({
   route,
@@ -28,22 +28,8 @@ const PhoningCharterScreen: FunctionComponent<PhoningCharterScreenProp> = ({
         })
       })
       .catch((error: Error) => {
-        displayError(GenericErrorMapper.mapErrorMessage(error))
+        AlertUtils.showNetworkAlert(error, undefined)
       })
-  }
-
-  const displayError = (error: string) => {
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.ok'),
-          style: 'default',
-        },
-      ],
-      { cancelable: false },
-    )
   }
 
   const markdownStyle = { body: styles.chartContainer }

--- a/src/screens/phoningSessionLoader/PhoningSessionLoaderScreen.tsx
+++ b/src/screens/phoningSessionLoader/PhoningSessionLoaderScreen.tsx
@@ -11,11 +11,11 @@ import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
 import { PhoningSessionLoaderScreenProps, Screen } from '../../navigation'
 import { Colors, Spacing, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { CloseButton } from '../shared/NavigationHeaderButton'
 import { VerticalSpacer } from '../shared/Spacer'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { usePreventGoingBack } from '../shared/usePreventGoingBack.hook'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const PhoningSessionLoaderScreen: FunctionComponent<PhoningSessionLoaderScreenProps> = ({
   navigation,
@@ -81,14 +81,7 @@ const PhoningSessionLoaderScreen: FunctionComponent<PhoningSessionLoaderScreenPr
                 <CloseButton onPress={() => navigation.pop()} />
               ),
             })
-            setStatefulState(
-              new ViewState.Error(
-                GenericErrorMapper.mapErrorMessage(error),
-                () => {
-                  loadSession()
-                },
-              ),
-            )
+            setStatefulState(ViewStateUtils.networkError(error, loadSession))
           }
         })
     }

--- a/src/screens/phoningSessionLoaderPermanentCampaign/PhoningSessionLoaderPermanentCampaignScreen.tsx
+++ b/src/screens/phoningSessionLoaderPermanentCampaign/PhoningSessionLoaderPermanentCampaignScreen.tsx
@@ -4,7 +4,7 @@ import React, {
   useEffect,
   useState,
 } from 'react'
-import { Text, StyleSheet, Alert } from 'react-native'
+import { Text, StyleSheet } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import { PhoningSession } from '../../core/entities/PhoningSession'
 import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
@@ -19,7 +19,7 @@ import { CloseButton } from '../shared/NavigationHeaderButton'
 import { FlexibleVerticalSpacer, VerticalSpacer } from '../shared/Spacer'
 import { PhoningSessionNavigationData } from '../shared/PhoningSessionNavigationData'
 import LoadingOverlay from '../shared/LoadingOverlay'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
+import { AlertUtils } from '../shared/AlertUtils'
 
 const PhoningSessionLoaderPermanentCampaignScreen: FunctionComponent<PhoningSessionLoaderPermanentCampaignScreenProp> = ({
   navigation,
@@ -51,21 +51,7 @@ const PhoningSessionLoaderPermanentCampaignScreen: FunctionComponent<PhoningSess
         setIsLoading(false)
       })
       .catch((error) => {
-        Alert.alert(
-          i18n.t('common.error_title'),
-          GenericErrorMapper.mapErrorMessage(error),
-          [
-            {
-              text: i18n.t('common.error_retry'),
-              onPress: loadSession,
-            },
-            {
-              text: i18n.t('common.cancel'),
-              style: 'cancel',
-            },
-          ],
-          { cancelable: false },
-        )
+        AlertUtils.showNetworkAlert(error, loadSession)
       })
   }, [route.params.campaignId, handleSession])
 

--- a/src/screens/phoningTutorial/PhoningTutorialScreen.tsx
+++ b/src/screens/phoningTutorial/PhoningTutorialScreen.tsx
@@ -11,9 +11,9 @@ import PhoningCampaignRepository from '../../data/PhoningCampaignRepository'
 import { Colors, Spacing } from '../../styles'
 import { PhoningTutorialScreenProp } from '../../navigation'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { useFocusEffect } from '@react-navigation/core'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 export interface TutorialResources {
   content: string
@@ -41,11 +41,7 @@ const PhoningTutorialScreen: FunctionComponent<PhoningTutorialScreenProp> = ({
         setStatefulState(new ViewState.Content({ content: markdown }))
       })
       .catch((error) => {
-        setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
-            fetchData()
-          }),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetchData))
       })
   }, [])
 

--- a/src/screens/pollDetail/PollDetailScreen.tsx
+++ b/src/screens/pollDetail/PollDetailScreen.tsx
@@ -7,7 +7,6 @@ import PollsRepository from '../../data/PollsRepository'
 import { Poll } from '../../core/entities/Poll'
 import PollDetailScreenLoaded from './PollDetailScreenLoaded'
 import { StatefulView, ViewState } from '../shared/StatefulView'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import {
   CloseButton,
   NavigationHeaderButton,
@@ -16,6 +15,7 @@ import ModalOverlay from '../shared/ModalOverlay'
 import PollDetailTools from './PollDetailTools'
 import { useTheme } from '../../themes'
 import { useBackHandler } from '../shared/useBackHandler.hook'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const PollDetailScreen = ({ route, navigation }: PollDetailScreenProps) => {
   const { theme } = useTheme()
@@ -71,12 +71,7 @@ const PollDetailScreen = ({ route, navigation }: PollDetailScreenProps) => {
       })
       .catch((error) => {
         console.error(error)
-        setStatefulState(
-          new ViewState.Error(
-            GenericErrorMapper.mapErrorMessage(error),
-            fetchPoll,
-          ),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetchPoll))
       })
   }
 

--- a/src/screens/pollDetail/PollDetailScreenLoaded.tsx
+++ b/src/screens/pollDetail/PollDetailScreenLoaded.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import { StyleSheet, View, Alert, FlatList } from 'react-native'
+import { StyleSheet, View, FlatList } from 'react-native'
 import SafeAreaView from 'react-native-safe-area-view'
 import PollDetailProgressBar from './PollDetailProgressBar'
 import { Colors, Spacing } from '../../styles'
@@ -16,15 +16,14 @@ import { PollDetailProgressBarViewModelMapper } from './PollDetailProgressBarVie
 import { PollDetailNavigationButtonsViewModelMapper } from './PollDetailNavigationButtonsViewModelMapper'
 import PollsRepository from '../../data/PollsRepository'
 import LoadingOverlay from '../shared/LoadingOverlay'
-import i18n from '../../utils/i18n'
 import { StackNavigationProp } from '@react-navigation/stack'
 import { PollDetailModalParamList, Screen } from '../../navigation'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { LocationManager } from '../../utils/LocationManager'
 import { CompoundPollDetailComponentProvider } from './providers/CompoundPollDetailComponentProvider'
 import { PollDetailRemoteQuestionComponentProvider } from './providers/PollDetailRemoteQuestionComponentProvider'
 import { PollDetailUserInformationsComponentProvider } from './providers/PollDetailUserInformationsComponentProvider'
 import { PollResult } from '../../core/entities/PollResult'
+import { AlertUtils } from '../shared/AlertUtils'
 
 type Props = Readonly<{
   poll: Poll
@@ -77,25 +76,6 @@ const PollDetailScreenLoaded: FunctionComponent<Props> = ({
     })
   }, [currentStep])
 
-  const displayError = (error: string) => {
-    console.log('Displaying error ', error)
-    Alert.alert(
-      i18n.t('common.error_title'),
-      error,
-      [
-        {
-          text: i18n.t('common.error_retry'),
-          onPress: postAnswers,
-        },
-        {
-          text: i18n.t('common.cancel'),
-          style: 'cancel',
-        },
-      ],
-      { cancelable: false },
-    )
-  }
-
   const postAnswers = async () => {
     setIsLoading(true)
 
@@ -109,7 +89,7 @@ const PollDetailScreenLoaded: FunctionComponent<Props> = ({
         })
       })
       .catch((error) => {
-        displayError(GenericErrorMapper.mapErrorMessage(error))
+        AlertUtils.showNetworkAlert(error, postAnswers)
       })
       .finally(() => setIsLoading(false))
   }

--- a/src/screens/pollDetail/PollDetailTools.tsx
+++ b/src/screens/pollDetail/PollDetailTools.tsx
@@ -4,9 +4,9 @@ import { Tool } from '../../core/entities/Tool'
 import ToolsRepository from '../../data/ToolsRepository'
 import { Colors, Spacing, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { ExternalLink } from '../shared/ExternalLink'
 import { StatefulView, ViewState } from '../shared/StatefulView'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 import PollDetailToolRow from './PollDetailToolRow'
 
 const Separator = () => {
@@ -26,9 +26,7 @@ const PollDetailTools = () => {
         setStatefulState(new ViewState.Content(tools))
       })
       .catch((error) => {
-        setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), fetch),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetch))
       })
   }
 

--- a/src/screens/polls/PollsScreen.tsx
+++ b/src/screens/polls/PollsScreen.tsx
@@ -17,12 +17,12 @@ import { PollRowViewModel } from './PollRowViewModel'
 import { PollsScreenViewModelMapper } from './PollsScreenViewModelMapper'
 import { PollsScreenProps, Screen } from '../../navigation'
 import { StatefulView, ViewState } from '../shared/StatefulView'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { PollsScreenViewModel } from './PollsScreenViewModel'
 import { useTheme } from '../../themes'
 import { GetPollsInteractor } from '../../core/interactor/GetPollsInteractor'
 import { ServerTimeoutError } from '../../core/errors'
 import { useFocusEffect } from '@react-navigation/native'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const PollsScreen = ({ navigation }: PollsScreenProps) => {
   const { theme } = useTheme()
@@ -47,13 +47,10 @@ const PollsScreen = ({ navigation }: PollsScreenProps) => {
             return
           }
           setStatefulState(
-            new ViewState.Error(
-              GenericErrorMapper.mapErrorMessage(error),
-              () => {
-                setStatefulState(new ViewState.Loading())
-                fetchData()
-              },
-            ),
+            ViewStateUtils.networkError(error, () => {
+              setStatefulState(new ViewState.Loading())
+              fetchData()
+            }),
           )
         })
         .finally(() => setRefreshing(false))

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -8,7 +8,6 @@ import { StatefulView, ViewState } from '../shared/StatefulView'
 import ProfileAnonymous from './ProfileAnonymous'
 import { Screen } from '../../navigation'
 import ProfileAuthenticated from './ProfileAuthenticated'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import {
   GetUserProfileInteractor,
   GetUserProfileInteractorResult,
@@ -18,6 +17,7 @@ import {
 import { ProfileScreenViewModelMapper } from './ProfileScreenViewModelMapper'
 import { ServerTimeoutError } from '../../core/errors'
 import { CloseButton } from '../shared/NavigationHeaderButton'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const ProfileScreen: FC<ProfileScreenProps> = ({ navigation }) => {
   const [statefulState, setStatefulState] = useState<
@@ -100,9 +100,7 @@ const ProfileScreen: FC<ProfileScreenProps> = ({ navigation }) => {
             if (isNetworkError && cacheJustLoaded) {
               return
             }
-            setStatefulState(
-              new ViewState.Error(GenericErrorMapper.mapErrorMessage(error)),
-            )
+            setStatefulState(ViewStateUtils.networkError(error))
           })
       }
 

--- a/src/screens/regions/RegionScreen.tsx
+++ b/src/screens/regions/RegionScreen.tsx
@@ -6,12 +6,12 @@ import RegionsRepository from '../../data/RegionsRepository'
 import { Colors, Spacing, Styles, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
 import { PrimaryButton } from '../shared/Buttons'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { RegionViewModel } from './RegionViewModel'
 import { RegionViewModelMapper } from './RegionViewModelMapper'
 import { RegionScreenProps } from '../../navigation'
 import { ExternalLink } from '../shared/ExternalLink'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 type Props = Readonly<RegionScreenProps>
 
@@ -31,18 +31,15 @@ const RegionScreen: FC<Props> = ({ route }) => {
           )
           setStatefulState(new ViewState.Content(viewModel))
         } else {
+          // This is a fatal error, should not happen
           setStatefulState(
-            new ViewState.Error(
-              GenericErrorMapper.mapErrorMessage(
-                new Error('No campaign for region.'),
-              ),
-            ),
+            ViewStateUtils.networkError(new Error('No campaign for region.')),
           )
         }
       })
       .catch((error) => {
         setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), () => {
+          ViewStateUtils.networkError(error, () => {
             setStatefulState(new ViewState.Loading())
             fetchData()
           }),

--- a/src/screens/shared/AlertUtils.ts
+++ b/src/screens/shared/AlertUtils.ts
@@ -1,0 +1,44 @@
+import { Alert, AlertButton } from 'react-native'
+import i18n from '../../utils/i18n'
+import { GenericErrorMapper } from './ErrorMapper'
+
+interface AlertOptions {
+  message?: string
+}
+
+export const AlertUtils = {
+  showNetworkAlert: (
+    error: Error,
+    onRetry: (() => void) | undefined,
+    options: AlertOptions = {},
+  ) => {
+    let alertButtons: AlertButton[]
+    if (onRetry !== undefined) {
+      alertButtons = [
+        {
+          text: i18n.t('common.error_retry'),
+          style: 'default',
+          onPress: onRetry,
+        },
+        {
+          text: i18n.t('shared.cancel'),
+          style: 'cancel',
+        },
+      ]
+    } else {
+      alertButtons = [
+        {
+          text: i18n.t('common.ok'),
+          style: 'default',
+        },
+      ]
+    }
+
+    Alert.alert(
+      i18n.t('common.error_title'),
+      options.message ?? GenericErrorMapper.mapErrorMessage(error),
+      alertButtons,
+      { cancelable: false },
+    )
+  },
+}

--- a/src/screens/shared/ErrorMapper.ts
+++ b/src/screens/shared/ErrorMapper.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   NotFoundError,
   DepartmentNotFoundError,
+  EventSubscriptionError,
 } from '../../core/errors'
 import i18n from '../../utils/i18n'
 
@@ -25,6 +26,8 @@ export const GenericErrorMapper = {
       return i18n.t('common.error.not_found')
     } else if (error instanceof DepartmentNotFoundError) {
       return i18n.t('anonymousloginzipcode.invalid_code')
+    } else if (error instanceof EventSubscriptionError) {
+      return error.message
     } else {
       return i18n.t('common.error.generic')
     }

--- a/src/screens/shared/ErrorMapper.ts
+++ b/src/screens/shared/ErrorMapper.ts
@@ -8,6 +8,7 @@ import {
   DepartmentNotFoundError,
   EventSubscriptionError,
 } from '../../core/errors'
+import { ErrorMonitor } from '../../utils/ErrorMonitor'
 import i18n from '../../utils/i18n'
 
 export const GenericErrorMapper = {
@@ -29,8 +30,10 @@ export const GenericErrorMapper = {
     } else if (error instanceof EventSubscriptionError) {
       return error.message
     } else if (error instanceof TypeError) {
+      ErrorMonitor.log('[UI] Bad format', { error: error.message })
       return i18n.t('common.error.parsing')
     } else {
+      ErrorMonitor.log('[UI] Unhandled error', { error: error.message })
       return i18n.t('common.error.generic')
     }
   },

--- a/src/screens/shared/ErrorMapper.ts
+++ b/src/screens/shared/ErrorMapper.ts
@@ -28,6 +28,8 @@ export const GenericErrorMapper = {
       return i18n.t('anonymousloginzipcode.invalid_code')
     } else if (error instanceof EventSubscriptionError) {
       return error.message
+    } else if (error instanceof TypeError) {
+      return i18n.t('common.error.parsing')
     } else {
       return i18n.t('common.error.generic')
     }

--- a/src/screens/shared/ViewStateUtils.ts
+++ b/src/screens/shared/ViewStateUtils.ts
@@ -1,0 +1,11 @@
+import { GenericErrorMapper } from './ErrorMapper'
+import { ViewState } from './StatefulView'
+
+export const ViewStateUtils = {
+  networkError: <T>(error: Error, onRetry?: () => void): ViewState.Type<T> => {
+    return new ViewState.Error(
+      GenericErrorMapper.mapErrorMessage(error),
+      onRetry,
+    )
+  },
+}

--- a/src/screens/tools/ToolsScreen.tsx
+++ b/src/screens/tools/ToolsScreen.tsx
@@ -5,13 +5,13 @@ import { Tool } from '../../core/entities/Tool'
 import ToolsRepository from '../../data/ToolsRepository'
 import { Colors, Spacing, Typography } from '../../styles'
 import i18n from '../../utils/i18n'
-import { GenericErrorMapper } from '../shared/ErrorMapper'
 import { StatefulView, ViewState } from '../shared/StatefulView'
 import { ToolRow } from './ToolRow'
 import { ToolRowViewModel } from './ToolRowViewModel'
 import { ToolRowViewModelMapper } from './ToolRowViewModelMapper'
 import { useTheme } from '../../themes'
 import { ExternalLink } from '../shared/ExternalLink'
+import { ViewStateUtils } from '../shared/ViewStateUtils'
 
 const ToolsScreen = () => {
   const [statefulState, setStatefulState] = useState<
@@ -33,9 +33,7 @@ const ToolsScreen = () => {
         setStatefulState(new ViewState.Content(toolsViewModel))
       })
       .catch((error) => {
-        setStatefulState(
-          new ViewState.Error(GenericErrorMapper.mapErrorMessage(error), fetch),
-        )
+        setStatefulState(ViewStateUtils.networkError(error, fetch))
       })
   }
 


### PR DESCRIPTION
- Create `AlertUtils.showNetworkAlert ` and `ViewStateUtils.networkError` to centralize error handling.
- Add an user friendly message for `TypeError`
- Log unhandled errors to Sentry to help future debugging