### PR TITLE
[Alert] use description property for meeting alert

### DIFF
--- a/src/components/Cards/AlertCard/AlertCard.tsx
+++ b/src/components/Cards/AlertCard/AlertCard.tsx
@@ -87,7 +87,7 @@ const AlertMeetingShareCard = ({ payload, ...props }: AlertVoxCardProps) => {
           </XStack>
 
           <XStack flexShrink={1}>
-            <Text.MD multiline>Vous êtes inscrit. Et si vous le partagiez autour de vous ?</Text.MD>
+            <Text.MD multiline>{payload.description}</Text.MD>
           </XStack>
         </YStack>
         <XStack gap="$small">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The alert sharing card now displays a dynamic description based on provided data, allowing for personalized, context-specific messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->