### PR TITLE
fix(event): format web calendar dates in event timezone

### DIFF
--- a/src/modules/Calendar/Calendar.web.ts
+++ b/src/modules/Calendar/Calendar.web.ts
@@ -1,22 +1,30 @@
 import { useToastController } from '@tamagui/toast'
 import { atcb_action } from 'add-to-calendar-button'
-import { formatDate } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 import { UseCreateEvent } from './CalendarTypes'
 import { isAllday as getIsAllDay, handleCreateEventError, successToast } from './utils'
+
+const toDate = (value: Date | string | undefined): Date | undefined => {
+  if (value == null) return undefined
+  return value instanceof Date ? value : new Date(value)
+}
 
 const useCreateEvent: UseCreateEvent = () => {
   const toast = useToastController()
   return async (event) => {
     const isAllday = getIsAllDay(event)
+    const timeZone = event.timeZone || 'Europe/Paris'
+    const start = toDate(event.startDate)
+    const end = toDate(event.endDate)
     return atcb_action({
       name: event.title,
       description: event.notes,
-      startDate: event.startDate ? formatDate(event.startDate, 'yyyy-MM-dd') : undefined,
-      endDate: !isAllday && event.endDate ? formatDate(event.endDate, 'yyyy-MM-dd') : undefined,
-      startTime: !isAllday && event.startDate ? formatDate(event.startDate, 'HH:mm') : undefined,
-      endTime: !isAllday && event.endDate ? formatDate(event.endDate, 'HH:mm') : undefined,
-      location: event.location,
-      timeZone: event.timeZone || 'Europe/Paris',
+      startDate: start ? formatInTimeZone(start, timeZone, 'yyyy-MM-dd') : undefined,
+      endDate: !isAllday && end ? formatInTimeZone(end, timeZone, 'yyyy-MM-dd') : undefined,
+      startTime: !isAllday && start ? formatInTimeZone(start, timeZone, 'HH:mm') : undefined,
+      endTime: !isAllday && end ? formatInTimeZone(end, timeZone, 'HH:mm') : undefined,
+      location: event.location ?? undefined,
+      timeZone,
       language: 'fr',
       options: ['Apple', 'Google', 'iCal', 'Microsoft365', 'MicrosoftTeams', 'Outlook.com', 'Yahoo'],
     })


### PR DESCRIPTION
## Description

Correction du bug de double décalage horaire pour les Français à l’étranger lorsqu’ils ajoutent un événement à leur calendrier

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)
