### PR TITLE
fix(cadre): apply design review to militants UI

### DIFF
--- a/src/features_next/militants/components/MilitantCadreItem.tsx
+++ b/src/features_next/militants/components/MilitantCadreItem.tsx
@@ -160,9 +160,9 @@ function MilitantCadreItemInner({
 
   const isMobileLayout = media.md || media.sm
   const col1Width = isMobileLayout ? '100%' : '25%'
-  const col2Width = isMobileLayout ? '100%' : '36%'
-  const col3Width = isMobileLayout ? '50%' : '22%'
-  const col4Width = isMobileLayout ? '50%' : '17%'
+  const col2Width = isMobileLayout ? '100%' : '35%'
+  const col3Width = isMobileLayout ? '50%' : '24%'
+  const col4Width = isMobileLayout ? '50%' : '16%'
 
   const circonscription = instances?.find((i) => i.type === 'circonscription')
   const assembly = instances?.find((i) => i.type === 'assembly')
@@ -216,15 +216,13 @@ function MilitantCadreItemInner({
             {elect_mandates.length > 0 && (
               <XStack gap={4}>
                 <TagChipRow tags={elect_mandates} theme="orange" />
-                {elect_tags && (
-                  <Chip theme="orange">
-                    <XStack gap={4} alignItems="center">
-                      {elect_tags.map((t, idx) => (
-                        <CotisationIconByCode key={`${t.code}-${idx}`} code={t.code} />
-                      ))}
-                    </XStack>
-                  </Chip>
-                )}
+                {elect_tags
+                  ? elect_tags.map((t, idx) => (
+                      <Chip key={`${t.code}-${idx}`} theme="orange" p="$xsmall" minWidth={22} justifyContent="center">
+                        <CotisationIconByCode code={t.code} />
+                      </Chip>
+                    ))
+                  : null}
               </XStack>
             )}
             {static_tags && <TagChipRow tags={static_tags} theme="gray" />}

--- a/src/features_next/militants/components/MilitantDetailsPanel/components/ElectMandatTap/index.tsx
+++ b/src/features_next/militants/components/MilitantDetailsPanel/components/ElectMandatTap/index.tsx
@@ -87,7 +87,7 @@ function MandateItem({ mandate, onEdit, onDelete }: MandateItemProps) {
       gap={12}
       backgroundColor={mandate.finish_at ? '$textSurface' : '$white1'}
       borderWidth={1}
-      borderColor={mandate.finish_at ? '$textOutline32' : '$textOutline'}
+      borderColor={mandate.finish_at ? '$textOutline20' : '$white1'}
       p="$medium"
       borderRadius="$small"
     >
@@ -409,10 +409,7 @@ export function ElectMandatTab({
 
   const { data, isError, isLoading: isElectLoading } = useAdherentElect(uuid, scope, canSeeElectedRepresentative)
   const isLoading = isElectLoading || isScopesLoading
-  const {
-    mutate: toggleExempt,
-    isPending: isTogglingExempt,
-  } = useMutationToggleAdherentElectExemptFromCotisation({
+  const { mutate: toggleExempt, isPending: isTogglingExempt } = useMutationToggleAdherentElectExemptFromCotisation({
     adherentUuid: uuid,
     scope,
     toastViewportName: PANEL_MODAL_TOAST_VIEWPORT,
@@ -437,7 +434,7 @@ export function ElectMandatTab({
   const declaredMandates = data?.declared_mandates || []
 
   return (
-    <YStack padding="$medium" gap="$medium" paddingBottom={80}>
+    <YStack px="$medium" py={24} gap="$medium" paddingBottom={80}>
       <Text semibold primary fontSize={16}>
         Mandats
       </Text>

--- a/src/features_next/militants/components/MilitantDetailsPanel/components/IdentiteTab.tsx
+++ b/src/features_next/militants/components/MilitantDetailsPanel/components/IdentiteTab.tsx
@@ -86,7 +86,7 @@ function InfoRow({
   seeSecureDataLoading?: boolean
 }) {
   return (
-    <YStack gap={12} bg="$textSurface" justifyContent="center" py="$small" pl={12} pr="$small" borderRadius="$small" minHeight={status ? 50 : 40}>
+    <YStack gap={12} bg="$textSurface" justifyContent="center" py="$small" pl={12} pr="$small" borderRadius="$xsmall" minHeight={status ? 50 : 40}>
       <XStack gap={12} alignItems="center">
         <Icon size={12} color={desactivated ? '$textDisabled' : '$textPrimary'} />
         <YStack flex={1} minWidth={0} gap={6}>
@@ -531,7 +531,7 @@ export function IdentiteTabContent({
   const staticTags = Array.isArray(summaryData.static_tags) ? summaryData.static_tags : []
 
   return (
-    <YStack padding="$medium" gap="$large" paddingBottom={80}>
+    <YStack px="$medium" py={24} gap="$large" paddingBottom={80}>
       <InformationsPersonnellesSection isLoading={isLoading} data={summaryData} uuid={uuid} scope={scope} />
       {(detailData || isLoading) && <SessionsSection isLoading={isLoading} data={detailData ?? null} />}
       <RolesSection roles={roles} />

--- a/src/features_next/militants/components/MilitantDetailsPanel/index.tsx
+++ b/src/features_next/militants/components/MilitantDetailsPanel/index.tsx
@@ -56,7 +56,7 @@ function MilitantProfilePicture({ imageUrl, displayName }: { imageUrl: string | 
 
   if (!imageUrl) {
     return (
-      <YStack alignItems="center" justifyContent="center" flex={1} height={200} bg="$gray8" pt="$large">
+      <YStack alignItems="center" justifyContent="center" height={200} bg="$gray8" pt="$large">
         <Text fontSize={128} medium color="$textDisabled">
           {initials}
         </Text>
@@ -65,7 +65,7 @@ function MilitantProfilePicture({ imageUrl, displayName }: { imageUrl: string | 
   }
 
   return (
-    <YStack flex={1} bg="$gray8" onLayout={onPhotoRowLayout}>
+    <YStack bg="$gray8" onLayout={onPhotoRowLayout}>
       <Animated.View style={photoFrameStyle}>
         <Image source={{ uri: imageUrl }} style={{ width: '100%', height: '100%' }} contentFit="cover" alt={displayName} />
         <View position="absolute" right="$small" bottom={12} opacity={0.6}>
@@ -89,7 +89,7 @@ function MilitantSummaryCard({ data, engagementScore = null }: { data: RestAdher
         <XStack gap="$medium" alignItems="center" flexWrap="wrap">
           <XStack gap={4} flex={1}>
             <YStack flex={1} minWidth={120} gap={2}>
-              <Text.SM semibold>{displayName}</Text.SM>
+              <Text.MD semibold>{displayName}</Text.MD>
               {age != null && <Text.SM secondary>{age} ans</Text.SM>}
               {engagementScore != null && (
                 <XStack alignItems="center" gap={8} marginTop={4}>
@@ -136,7 +136,7 @@ const TABS: { id: FicheMilitantTabId; label: string }[] = [
 
 function MilitantDetailTabs({ activeTab, onTabChange }: { activeTab: FicheMilitantTabId; onTabChange: (tab: FicheMilitantTabId) => void }) {
   return (
-    <XStack borderBottomWidth={2} borderTopWidth={1} borderColor="$borderColor" paddingHorizontal="$medium" mt="$medium">
+    <XStack borderBottomWidth={2} borderColor="$borderColor" paddingHorizontal="$medium" mt="$xsmall">
       {TABS.map((tab) => {
         const isActive = activeTab === tab.id
         return (

--- a/src/features_next/militants/components/MilitantListHeader.tsx
+++ b/src/features_next/militants/components/MilitantListHeader.tsx
@@ -94,11 +94,15 @@ export function MilitantHeaderPagination({ page, pageSize, totalItems, onPageCha
 
   return (
     <XStack justifyContent={media.sm ? 'space-between' : 'flex-end'} alignItems="center" gap={rightSlot ? 0 : '$medium'}>
-      <Text.SM>
-        <Text.SM secondary>{rangeText} sur </Text.SM>
-        <Text.SM semibold>{totalItems ?? '–'}</Text.SM>
-      </Text.SM>
-      {rightSlot ? <YStack>{rightSlot}</YStack> : null}
+      <Text.MD>
+        <Text.MD secondary>{rangeText} sur </Text.MD>
+        <Text.MD semibold>{totalItems ?? '–'}</Text.MD>
+      </Text.MD>
+      {rightSlot ? (
+        <YStack px="$small" ml="auto">
+          {rightSlot}
+        </YStack>
+      ) : null}
       <XStack gap={4}>
         <VoxButton
           variant="outlined"


### PR DESCRIPTION
## Description

Aligne l’UI militants avec les retours design : colonnes et chips sur la ligne cadre, en-tête de pagination, fiche (photo, onglets, texte) et onglets Identité / Mandats électifs (rayons, bordures, marges).

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)