### PR TITLE
fix(event): hide pinned banner on mobile scroll

### DIFF
--- a/app/(app)/(tabs)/evenements/index.tsx
+++ b/app/(app)/(tabs)/evenements/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, useMemo } from 'react'
 import { Link } from 'expo-router'
 import Head from 'expo-router/head'
-import { isWeb, YStack } from 'tamagui'
+import { isWeb, useMedia, YStack } from 'tamagui'
 import { Sparkle } from '@tamagui/lucide-icons'
 
 import Layout from '@/components/AppStructure/Layout/Layout'
@@ -36,17 +36,20 @@ const CreateEventFloatingButton = () => {
 }
 
 export default function EvenementsPage() {
+  const media = useMedia()
+  const banner = media.sm ? undefined : (
+    <Suspense fallback={null}>
+      <PinnedEventBanner />
+    </Suspense>
+  )
+
   return (
     <>
       <Head>
         <title>{metatags.createTitle('Nos événements')}</title>
       </Head>
       <Layout.Container
-        banner={
-          <Suspense fallback={null}>
-            <PinnedEventBanner />
-          </Suspense>
-        }
+        banner={banner}
         floatingContent={
           <Suspense fallback={null}>
             <CreateEventFloatingButton />

--- a/src/features_next/events/pages/detail/components/EventContent.tsx
+++ b/src/features_next/events/pages/detail/components/EventContent.tsx
@@ -39,7 +39,7 @@ const DateItem = (props: Partial<Pick<RestItemEvent, 'begin_at' | 'finish_at' | 
   )
 }
 
-const FloatingBackButton = () => {
+const FloatingBackButton = ({ withSafeArea = true }: { withSafeArea?: boolean }) => {
   const router = useRouter()
   const insets = useSafeAreaInsets()
   const fallbackPath: Href = '/'
@@ -53,7 +53,7 @@ const FloatingBackButton = () => {
   }
 
   return (
-    <YStack position="absolute" top={insets.top + 16} left={16} zIndex={100}>
+    <YStack position="absolute" top={(withSafeArea ? insets.top : 0) + 16} left={16} zIndex={100}>
       <VoxButton variant="contained" theme="gray" iconLeft={ArrowLeft} size="md" shrink onPress={handleBack} />
     </YStack>
   )
@@ -192,7 +192,7 @@ const MobileLayout = (props: EventItemProps) => {
           </YStack>
         </LayoutScrollView>
       </Layout.Main>
-      <FloatingBackButton />
+      <FloatingBackButton withSafeArea={Boolean(props.userUuid)} />
       <MobileBottomCTA {...props} />
     </>
   )

--- a/src/features_next/events/pages/feed/components/PinnedEventBanner.tsx
+++ b/src/features_next/events/pages/feed/components/PinnedEventBanner.tsx
@@ -9,14 +9,12 @@ import { fr } from 'date-fns/locale'
 
 import useLayoutSpacing from '@/components/AppStructure/hooks/useLayoutSpacing'
 import Text from '@/components/base/Text'
-import { SignInButton, SignUpButton } from '@/components/Buttons/AuthButton'
 import VoxCard from '@/components/VoxCard/VoxCard'
 import { getEventItemImageFallback, isEventPartial } from '@/features_next/events/utils'
 
 import { useSession } from '@/ctx/SessionProvider'
 import { useSuspensePinnedEvents } from '@/services/events/hook'
 import type { RestItemEvent, RestPublicItemEvent } from '@/services/events/schema'
-import { useGetProfil } from '@/services/profile/hook'
 
 import { FadingScrollView } from './FadingScrollView'
 
@@ -89,42 +87,6 @@ function PinnedEventCardContent({ event }: { event: PinnedEventItem }) {
   )
 }
 
-function PinnedEventAuthOverlay({ eventUuid }: { eventUuid: string }) {
-  const redirectUri = `/evenements/${eventUuid}?source=page_events_pinned`
-
-  return (
-    <YStack
-      position="absolute"
-      top={0}
-      left={0}
-      right={0}
-      bottom={0}
-      zIndex={10}
-      backgroundColor="$gray/16"
-      justifyContent="center"
-      alignItems="center"
-      paddingHorizontal={8}
-      paddingVertical={6}
-    >
-      <XStack
-        flexWrap="wrap"
-        justifyContent="center"
-        alignItems="center"
-        gap="$xsmall"
-        rowGap={6}
-        bg="$white1"
-        p="$medium"
-        borderRadius="$medium"
-        borderColor="$textOutline"
-        borderWidth={4}
-      >
-        <SignInButton redirectUri={redirectUri} size="sm" />
-        <SignUpButton size="sm" />
-      </XStack>
-    </YStack>
-  )
-}
-
 function PinnedEventCardWrapper({ sizeMode, isMobile, children }: { sizeMode: CardSizeMode; isMobile: boolean; children: ReactNode }) {
   if (sizeMode === 'split') {
     return (
@@ -150,19 +112,18 @@ function PinnedEventCardWrapper({ sizeMode, isMobile, children }: { sizeMode: Ca
 }
 
 const PinnedEventCard = memo(
-  ({ event, sizeMode, isMobile, userUuid }: { event: PinnedEventItem; sizeMode: CardSizeMode; isMobile: boolean; userUuid?: string }) => {
+  ({ event, sizeMode, isMobile }: { event: PinnedEventItem; sizeMode: CardSizeMode; isMobile: boolean }) => {
     const router = useRouter()
     const href = `/evenements/${event.slug}?source=page_events_pinned` as Href
-    const showAuthOverlay = isEventPartial(event) && !userUuid
 
     return (
       <PinnedEventCardWrapper sizeMode={sizeMode} isMobile={isMobile}>
         <YStack position="relative" flex={1} borderRadius="$medium" overflow="hidden">
           <VoxCard
-            cursor={showAuthOverlay ? 'default' : 'pointer'}
+            cursor="pointer"
             flex={1}
             width={sizeMode === 'split' ? '100%' : undefined}
-            onPress={showAuthOverlay ? undefined : () => router.push(href)}
+            onPress={() => router.push(href)}
             borderRadius="$medium"
             hoverStyle={{
               backgroundColor: '$textSurface',
@@ -175,7 +136,6 @@ const PinnedEventCard = memo(
               <PinnedEventCardContent event={event} />
             </VoxCard.Content>
           </VoxCard>
-          {showAuthOverlay ? <PinnedEventAuthOverlay eventUuid={event.uuid} /> : null}
         </YStack>
       </PinnedEventCardWrapper>
     )
@@ -184,15 +144,28 @@ const PinnedEventCard = memo(
 
 PinnedEventCard.displayName = 'PinnedEventCard'
 
-export function PinnedEventBanner() {
+type PinnedEventBannerProps = {
+  /**
+   * Applique le safe area top (défaut `true`).
+   * À désactiver (`false`) lorsque le banner est rendu dans un ScrollView/FlatList qui
+   * gère déjà le safe area (ex. iOS avec `contentInsetAdjustmentBehavior='automatic'`)
+   * pour éviter un double padding.
+   */
+  safeAreaTop?: boolean
+}
+
+export function PinnedEventBanner({ safeAreaTop = true }: PinnedEventBannerProps = {}) {
   const media = useMedia()
   const { session } = useSession()
-  const { data: userData } = useGetProfil({ enabled: Boolean(session) })
-  const userUuid = userData?.uuid
+  const isAuthenticated = Boolean(session)
   const { data } = useSuspensePinnedEvents()
-  const events = useMemo(() => data.pages.flatMap((p) => p?.items ?? []), [data.pages])
+  const events = useMemo(() => {
+    const allEvents = data.pages.flatMap((p) => p?.items ?? [])
+    if (isAuthenticated) return allEvents
+    return allEvents.filter((event) => !isEventPartial(event))
+  }, [data.pages, isAuthenticated])
   const isMobile = Boolean(media.sm)
-  const { paddingTop } = useLayoutSpacing({ top: true, left: false, right: false, bottom: false })
+  const { paddingTop } = useLayoutSpacing({ top: true, safeAreaTop, left: false, right: false, bottom: false })
 
   if (events.length === 0) return null
 
@@ -201,7 +174,7 @@ export function PinnedEventBanner() {
       <YStack width="100%" paddingTop={paddingTop}>
         <XStack width="100%" gap="$medium" alignItems="stretch" flexWrap="nowrap">
           {events.map((event) => (
-            <PinnedEventCard key={event.uuid} event={event} sizeMode="split" isMobile={isMobile} userUuid={userUuid} />
+            <PinnedEventCard key={event.uuid} event={event} sizeMode="split" isMobile={isMobile} />
           ))}
         </XStack>
       </YStack>
@@ -211,7 +184,7 @@ export function PinnedEventBanner() {
   if (events.length === 1) {
     return (
       <YStack width="100%" paddingTop={paddingTop} paddingHorizontal={isMobile ? 16 : 0} paddingBottom={isMobile ? 16 : 0}>
-        <PinnedEventCard event={events[0]} sizeMode="single" isMobile={isMobile} userUuid={userUuid} />
+        <PinnedEventCard event={events[0]} sizeMode="single" isMobile={isMobile} />
       </YStack>
     )
   }
@@ -228,7 +201,7 @@ export function PinnedEventBanner() {
       >
         <XStack flexDirection="row" alignItems="stretch" gap={16} paddingBottom={isMobile ? 16 : 0}>
           {events.map((event) => (
-            <PinnedEventCard key={event.uuid} event={event} sizeMode="scroll" isMobile={isMobile} userUuid={userUuid} />
+            <PinnedEventCard key={event.uuid} event={event} sizeMode="scroll" isMobile={isMobile} />
           ))}
         </XStack>
       </FadingScrollView>

--- a/src/features_next/events/pages/feed/index.tsx
+++ b/src/features_next/events/pages/feed/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, Suspense, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { FlatList, Platform, ViewToken } from 'react-native'
 import { useScrollToTop } from '@react-navigation/native'
 import { getToken, Spinner, useMedia, YStack } from 'tamagui'
@@ -13,6 +13,7 @@ import TrackImpressionWeb from '@/components/TrackImpressionWeb'
 import EventListItem from '@/features_next/events/components/EventListItem'
 import { eventFiltersState } from '@/features_next/events/store/filterStore'
 import { groupEventsBySection } from '@/features_next/events/utils'
+import { PinnedEventBanner } from '@/features_next/events/pages/feed/components/PinnedEventBanner'
 
 import { useSession } from '@/ctx/SessionProvider'
 import { usePinnedEventsInfiniteQuery, useSuspensePaginatedEvents } from '@/services/events/hook'
@@ -85,7 +86,10 @@ const EventFeed = () => {
   const feedContentContainerStyle = useMemo(
     () => ({
       gap: getToken('$medium', 'space'),
-      paddingTop: hasPinnedBannerContent && media.sm ? 8 : Platform.OS === 'ios' ? 8 : listSpacing.paddingTop,
+      // En mobile avec banner pinned, celui-ci est rendu dans `ListHeaderComponent` et
+      // fournit déjà son propre paddingTop (safe area). On neutralise donc le paddingTop
+      // du container pour éviter un double espacement.
+      paddingTop: hasPinnedBannerContent && media.sm ? 0 : Platform.OS === 'ios' ? 8 : listSpacing.paddingTop,
     }),
     [hasPinnedBannerContent, listSpacing.paddingTop, media.sm],
   )
@@ -226,14 +230,31 @@ const EventFeed = () => {
     if (value === 'events' || value === 'myEvents') setActiveTab(value)
   }, [])
 
+  const bannerSafeAreaTop = useMemo(() => {
+    // - Non authentifié : Layout rend un Header en mobile qui applique déjà `insets.top`
+    //   (voir `src/components/AppStructure/Layout/Layout.tsx` + `Header/index.tsx`).
+    // - Authentifié sur iOS : la FlatList applique le safe area via
+    //   `contentInsetAdjustmentBehavior='automatic'`.
+    // - Authentifié sur Android : rien n'applique le safe area en amont, le banner s'en charge.
+    if (!isAuth) return false
+    return Platform.OS === 'android'
+  }, [isAuth])
+
   const listHeader = useMemo(
     () => (
-      <YStack gap="$medium" px={media.sm ? '$medium' : 0}>
-        {isAuth && <BigSwitch options={EVENTS_SWITCH_OPTIONS} value={activeTab} onChange={handleSwitchChange} />}
-        {!media.gtMd && <EventsSideContent />}
+      <YStack>
+        {media.sm ? (
+          <Suspense fallback={null}>
+            <PinnedEventBanner safeAreaTop={bannerSafeAreaTop} />
+          </Suspense>
+        ) : null}
+        <YStack gap="$medium" px={media.sm ? '$medium' : 0}>
+          {isAuth && <BigSwitch options={EVENTS_SWITCH_OPTIONS} value={activeTab} onChange={handleSwitchChange} />}
+          {!media.gtMd && <EventsSideContent />}
+        </YStack>
       </YStack>
     ),
-    [activeTab, media.gtMd, media.sm, isAuth, handleSwitchChange],
+    [activeTab, media.gtMd, media.sm, isAuth, handleSwitchChange, bannerSafeAreaTop],
   )
 
   return (


### PR DESCRIPTION
## Description

Les événements épinglés font désormais partie du flux de la liste sur mobile.
Les espacements de safe area ont été corrigés pour éviter les doublons selon plateforme et état connecté/déconnecté.

## Type de changement

- [x] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)
