### PR TITLE
fix(profile): add auth wall to profile subpages

### DIFF
--- a/app/(app)/profil/_layout.tsx
+++ b/app/(app)/profil/_layout.tsx
@@ -1,0 +1,13 @@
+import { Redirect, Slot } from 'expo-router'
+
+import { useSession } from '@/ctx/SessionProvider'
+
+export default function ProfilLayout() {
+  const { isAuth } = useSession()
+
+  if (!isAuth) {
+    return <Redirect href={'/evenements'} />
+  }
+
+  return <Slot />
+}


### PR DESCRIPTION
## Description

Cette PR sécurise toutes les sous-pages du profil en ajoutant un auth wall au niveau du layout profil, afin de rediriger les utilisateurs non connectés vers evenements.

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)
