### PR TITLE
fix(auth): prevent auth callback deep-link routing

### DIFF
--- a/src/hooks/useDeepLinkHandler.tsx
+++ b/src/hooks/useDeepLinkHandler.tsx
@@ -14,9 +14,15 @@ export default function useDeepLinkHandler() {
     if (Platform.OS === 'web') return
 
     const onDeepLink: Linking.URLListener = ({ url }) => {
-      const path = Linking.parse(url)?.path
-      // Don't route if already on the requested page
-      if (path && pathname !== path) {
+      const parsed = Linking.parse(url)
+      const path = parsed.path?.replace(/^\/+/, '')
+      const queryParams = parsed.queryParams ?? {}
+
+      if ('code' in queryParams || 'state' in queryParams || '_switch_user' in queryParams) {
+        return
+      }
+
+      if (path && pathname !== `/${path}`) {
         router.push(`/${path}`)
       }
     }

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
-import clientEnv from '@/config/clientEnv'
-import { AUTHORIZATION_ENDPOINT, getDiscoveryDocument, REGISTRATION_ENDPOINT } from '@/config/discoveryDocument'
 import * as AuthSession from 'expo-auth-session'
 import { DiscoveryDocument } from 'expo-auth-session'
 import * as WebBrowser from 'expo-web-browser'
 import { maybeCompleteAuthSession } from 'expo-web-browser'
 import { isWeb } from 'tamagui'
+
+import clientEnv from '@/config/clientEnv'
+import { AUTHORIZATION_ENDPOINT, getDiscoveryDocument, REGISTRATION_ENDPOINT } from '@/config/discoveryDocument'
+
 import useBrowserWarmUp from './useBrowserWarmUp'
 
 maybeCompleteAuthSession()
@@ -57,7 +59,11 @@ export const useLogin = () => {
   const [req, , promptAsync] = useCodeAuthRequest() ?? []
   return async (payload?: { code?: string; sessionId?: string; state?: string }) => {
     if (payload?.code) {
-      WebBrowser.dismissAuthSession()
+      try {
+        WebBrowser.dismissAuthSession()
+      } catch {
+        // No auth session to dismiss (e.g. return from external mail app flow).
+      }
       return exchangeCodeAsync({ code: payload.code, sessionId: payload.sessionId })
     }
 

--- a/src/services/logout/api.ts
+++ b/src/services/logout/api.ts
@@ -28,7 +28,11 @@ export function useLogOut() {
 
       const lol = Linking.addEventListener('url', async (event) => {
         if (event.url.startsWith(REDIRECT_URI)) {
-          WebBrowser.dismissBrowser()
+          try {
+            WebBrowser.dismissBrowser()
+          } catch {
+            // Browser can already be closed depending on iOS hand-off timing.
+          }
           lol.remove()
         }
       })


### PR DESCRIPTION
## Description

Le correctif empêche le crash au retour du magic link en évitant une navigation deep-link concurrente pendant le callback d’authentification et en rendant sûrs les appels de fermeture du navigateur (dismissAuthSession/dismissBrowser) lorsqu’aucune session web n’est active.

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)