### PR TITLE
fix(event): support invitation counts and live badge

### DIFF
--- a/src/features_next/events/components/EventListItemLiveBadge.tsx
+++ b/src/features_next/events/components/EventListItemLiveBadge.tsx
@@ -1,6 +1,6 @@
 import { XStack } from 'tamagui'
 import { Radio } from '@tamagui/lucide-icons'
-import { isToday } from 'date-fns'
+import { isAfter, isBefore, isEqual, isToday } from 'date-fns'
 
 import VoxCard from '@/components/VoxCard/VoxCard'
 
@@ -11,10 +11,16 @@ import { isEventHasNationalLive, isEventStarted } from '../utils'
 
 export const EventListItemLiveBadge = ({ event }: { event: Partial<RestItemEvent> }) => {
   const startDate = event.begin_at ? new Date(event.begin_at) : null
-  if (startDate === null) return false
-  const isStartToday = isToday(startDate)
+  const endDate = event.finish_at ? new Date(event.finish_at) : null
 
-  return isEventHasNationalLive(event) && isStartToday ? (
+  if (startDate === null) return false
+
+  const now = new Date()
+  const isLiveNow = endDate ? (isAfter(now, startDate) || isEqual(now, startDate)) && (isBefore(now, endDate) || isEqual(now, endDate)) : false
+  const isLiveDayBeforeStart = isToday(startDate) && (isBefore(now, startDate) || isEqual(now, startDate))
+  const shouldDisplayBadge = isLiveDayBeforeStart || isLiveNow
+
+  return isEventHasNationalLive(event) && shouldDisplayBadge ? (
     <XStack>
       <VoxCard.Chip alert icon={Radio}>
         {isEventStarted(event) ? 'En direct' : `En direct à ${getHumanFormattedTime(startDate)}`}

--- a/src/features_next/events/pages/create-edit/components/ConfirmAlert.tsx
+++ b/src/features_next/events/pages/create-edit/components/ConfirmAlert.tsx
@@ -25,6 +25,7 @@ type ConfirmAlertProps = {
   setValue: UseFormSetValue<EventFormData>
   isAgoraLeader?: boolean
   agoraUuid?: string | null
+  committeeUuid?: string | null
   scope?: string | null
 }
 
@@ -55,12 +56,13 @@ const VisibilityReview = (props: { visibility: string }) => {
   ) : null
 }
 
-const CountInvitation = (props: { visibility: string; agoraUuid?: string | null; scope?: string | null }) => {
-  const shouldCount = props.visibility === 'invitation' && !!props.agoraUuid && !!props.scope
+const CountInvitation = (props: { visibility: string; agoraUuid?: string | null; committeeUuid?: string | null; scope?: string | null }) => {
+  const shouldCount = props.visibility === 'invitation' && (!!props.agoraUuid || !!props.committeeUuid) && !!props.scope
 
   const { data, isLoading } = useCountInvitationsEvent({
     roles: undefined,
     agora: shouldCount ? props.agoraUuid! : undefined,
+    committee: shouldCount ? props.committeeUuid! : undefined,
     scope: shouldCount ? props.scope! : '',
   })
 
@@ -186,7 +188,9 @@ const _ConfirmAlert = forwardRef<ModalRef, ConfirmAlertProps>((props, ref) => {
               )}
             />
           ) : null}
-          {!hidden && visibility === 'invitation' ? <CountInvitation visibility={visibility} agoraUuid={props.agoraUuid} scope={props.scope} /> : null}
+          {!hidden && visibility === 'invitation' ? (
+            <CountInvitation visibility={visibility} agoraUuid={props.agoraUuid} committeeUuid={props.committeeUuid} scope={props.scope} />
+          ) : null}
         </YStack>
         <XStack gap="$medium">
           <VoxButton variant="outlined" flex={3} children="Annuler" onPress={handleCancel} theme="gray" />

--- a/src/features_next/events/pages/create-edit/context.tsx
+++ b/src/features_next/events/pages/create-edit/context.tsx
@@ -242,6 +242,10 @@ const useEventFormData = ({ edit }: EventFormProps) => {
     return scopes.data?.list.find((x) => x.code === selectedScope)?.attributes?.agoras?.[0]?.uuid ?? null
   }, [selectedScope, scopes.data])
 
+  const committeeUuid = useMemo(() => {
+    return scopes.data?.list.find((x) => x.code === selectedScope)?.attributes?.committees?.[0]?.uuid ?? null
+  }, [selectedScope, scopes.data])
+
   const finalSubmit: SubmitHandler<EventFormData> = async (data) => {
     const { scope, image, mode, visio_url, post_address, ...payload } = data
     const fullScope = scopes.data?.list?.find((x) => x.code === scope) ?? { attributes: { committees: edit?.committee, agoras: edit?.agoras } }
@@ -333,6 +337,7 @@ const useEventFormData = ({ edit }: EventFormProps) => {
     setValue,
     isAgoraLeader,
     agoraUuid,
+    committeeUuid,
     scope: selectedScope,
   })
 

--- a/src/features_next/events/pages/create-edit/visibility-options.ts
+++ b/src/features_next/events/pages/create-edit/visibility-options.ts
@@ -56,6 +56,10 @@ const isCommitteeScope = (selectedScopeData?: SelectedScopeData) => {
 export const getVisibilityOptions = (selectedScopeData?: SelectedScopeData): SelectOption<EventFormData['visibility']>[] => {
   const scope = selectedScopeData?.code ?? ''
 
+  if (!scope) {
+    return ALL_VISIBILITY_OPTIONS
+  }
+
   if (scope?.startsWith('agora_')) {
     return ALL_VISIBILITY_OPTIONS
   }

--- a/src/services/events/hook/useEvents.ts
+++ b/src/services/events/hook/useEvents.ts
@@ -30,7 +30,7 @@ const buildEventsFiltersQueryKey = (filters: EventFilters | undefined) =>
   filters
     ? JSON.stringify({
         ...filters,
-        finishAfter: filters.finishAfter ? format(filters.finishAfter, 'yyyy-MM-dd') : '',
+        finishAfter: filters.finishAfter ? format(filters.finishAfter, 'yyyy-MM-dd HH:mm') : '',
       })
     : ''
 
@@ -314,12 +314,12 @@ export const useCancelEvent = () => {
   })
 }
 
-export const useCountInvitationsEvent = ({ roles, agora, scope }: RestPostCountInvitationsEventRequest & { scope: string }) => {
+export const useCountInvitationsEvent = ({ roles, agora, committee, scope }: RestPostCountInvitationsEventRequest & { scope: string }) => {
   return useQuery({
-    queryKey: [QUERY_KEY_SINGLE_EVENT, roles, agora, scope],
+    queryKey: [QUERY_KEY_SINGLE_EVENT, roles, agora, committee, scope],
     queryFn: () =>
       api.countInvitationsEvent({
-        payload: { roles, agora },
+        payload: { roles, agora, committee },
         scope,
       }),
     refetchOnMount: true,

--- a/src/services/events/paramsMapper.ts
+++ b/src/services/events/paramsMapper.ts
@@ -1,5 +1,7 @@
-import { EventFilters } from '@/core/entities/Event'
 import { format } from 'date-fns'
+
+import { EventFilters } from '@/core/entities/Event'
+
 import { RestGetEventsRequest } from './schema'
 
 type GetEventsSearchParametersMapperPropsBase = {
@@ -24,7 +26,7 @@ export type GetEventsSearchParametersMapperProps =
     } & GetEventsSearchParametersMapperPropsBase)
 
 const paramsCollection = {
-  finishAfter: (x: Date) => ({ 'finishAt[strictly_after]': format(x, 'yyyy-MM-dd') }),
+  finishAfter: (x: Date) => ({ 'finishAt[strictly_after]': format(x, 'yyyy-MM-dd HH:mm') }),
   searchText: (x: string) => ({ name: x }),
   eventMode: (x: string) => ({ mode: x }),
   orderBySubscriptions: (x: boolean) => ({ 'order[subscriptions]': x ? 'desc' : 'asc' }),

--- a/src/services/events/schema.ts
+++ b/src/services/events/schema.ts
@@ -292,6 +292,7 @@ export type RestPostCountInvitationsEventRequest = z.infer<typeof RestPostCountI
 export const RestPostCountInvitationsEventRequestSchema = z.object({
   roles: z.array(z.enum(['agora_president', 'animator', 'deputy', 'communication_manager', 'treasurer'])).nullish(),
   agora: z.string().nullish(),
+  committee: z.string().nullish(),
 })
 
 export const RestPostCountInvitationsEventResponseSchema = z.object({


### PR DESCRIPTION
## Description

Nous avons corrigé la modal de confirmation de création d’événement en prenant en charge le comptage des invitations pour les comités, tout en fiabilisant le visibility review.
Nous avons aussi ajusté le filtre des événements épinglés pour inclure l’heure (et pas seulement la date) et corrigé l’affichage du badge live pour qu’il respecte correctement la fenêtre begin_at / finish_at.

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)

