### PR TITLE
fix(event): voxcard alert event

### DIFF
--- a/src/components/VoxCard/VoxCard.tsx
+++ b/src/components/VoxCard/VoxCard.tsx
@@ -13,6 +13,7 @@ import { getFormatedVoxCardDate } from '../utils'
 
 export const CardFrame = styled(YStack, {
   backgroundColor: '$white1',
+  gap: '$medium',
   $gtSm: {
     borderRadius: 16,
   },
@@ -41,9 +42,7 @@ export type VoxCardFrameProps = ComponentProps<typeof CardFrame>
 export const VoxCardFrame = CardFrame.styleable(({ children, ...props }: VoxCardFrameProps, ref) => {
   return (
     <CardFrame {...props} ref={ref}>
-      <YStack gap="$medium" flex={1}>
-        {children}
-      </YStack>
+      {children}
     </CardFrame>
   )
 })


### PR DESCRIPTION
## Description

Correction du bug d'affichage des alertes en double sur la home

## Type de changement

- [x] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)