### PR TITLE
feat(event): reset hidden when visibility is invitation

### DIFF
--- a/src/features_next/events/pages/create-edit/components/EventFormDesktopScreen.tsx
+++ b/src/features_next/events/pages/create-edit/components/EventFormDesktopScreen.tsx
@@ -38,6 +38,7 @@ const EventFormAside = () => {
     handleOnChangeFinishAt,
     isAgoraLeader,
     isAgoraScope,
+    visibility,
   } = useEventFormContext()
 
   return (
@@ -65,7 +66,7 @@ const EventFormAside = () => {
 
         <Controller
           render={({ field }) => {
-            return <EventHiddenField value={field.value} onChange={field.onChange} />
+            return <EventHiddenField value={field.value} onChange={field.onChange} disabled={visibility === 'invitation'} />
           }}
           control={control}
           name="hidden"

--- a/src/features_next/events/pages/create-edit/components/EventFormMobileScreen.tsx
+++ b/src/features_next/events/pages/create-edit/components/EventFormMobileScreen.tsx
@@ -46,6 +46,7 @@ export default function EventFormMobileScreen() {
     ConfirmAlert,
     isAgoraLeader,
     isAgoraScope,
+    visibility,
   } = useEventFormContext()
 
   const globalPending = isPending || isUploadImagePending || isUploadDeletePending
@@ -135,7 +136,7 @@ export default function EventFormMobileScreen() {
                   />
                   <Controller
                     render={({ field }) => {
-                      return <EventHiddenField value={field.value} onChange={field.onChange} />
+                      return <EventHiddenField value={field.value} onChange={field.onChange} disabled={visibility === 'invitation'} />
                     }}
                     control={control}
                     name="hidden"

--- a/src/features_next/events/pages/create-edit/components/EventHiddenField.tsx
+++ b/src/features_next/events/pages/create-edit/components/EventHiddenField.tsx
@@ -12,20 +12,21 @@ import VoxCard from '@/components/VoxCard/VoxCard'
 type EventHiddenFieldProps = {
   value: boolean
   onChange: (value: boolean) => void
+  disabled?: boolean
 }
-const EventHiddenField = ({ value, onChange }: EventHiddenFieldProps) => {
+const EventHiddenField = ({ value, onChange, disabled = false }: EventHiddenFieldProps) => {
   const [open, setOpen] = useState(false)
   const media = useMedia()
   return (
     <>
       <XStack alignItems="center" justifyContent="space-between" gap="$small" px="$medium">
         <XStack gap="$small">
-          <Text.MD secondary>Événement non répertorié ?</Text.MD>
+          <Text.MD color={disabled ? '$textDisabled' : '$textSecondary'}>Événement non répertorié ?</Text.MD>
           <Pressable onPress={() => setOpen(true)}>
             <Info size={16} color="$blue5" />
           </Pressable>
         </XStack>
-        <SwitchV2 checked={value} onPress={() => onChange(!value)} />
+        <SwitchV2 checked={value} disabled={disabled} onPress={() => !disabled && onChange(!value)} />
       </XStack>
       <ModalOrBottomSheet open={open} onClose={() => setOpen(false)}>
         <VoxCard maxWidth={media.sm ? undefined : 500} borderWidth={media.sm ? 0 : 1} paddingBottom={media.sm ? '$large' : undefined}>

--- a/src/features_next/events/pages/create-edit/context.tsx
+++ b/src/features_next/events/pages/create-edit/context.tsx
@@ -145,6 +145,7 @@ const useEventFormData = ({ edit }: EventFormProps) => {
 
   /** Dérivé du formulaire : évite un `useState` dupliqué et un `setMode` dans l’effet (règle set-state-in-effect). */
   const mode = useWatch({ control, name: 'mode' })
+  const visibility = useWatch({ control, name: 'visibility' })
 
   const handleOnChangeBeginAt = useCallback(
     (onChange: (y: Date) => void) => (x: Date) => {
@@ -238,6 +239,12 @@ const useEventFormData = ({ edit }: EventFormProps) => {
       setValue('mode', 'online', { shouldValidate: true })
     }
   }, [edit, getValues, isAgoraLeader, selectedScope, setValue, visibilityOptions])
+
+  useEffect(() => {
+    if (visibility === 'invitation' && getValues('hidden')) {
+      setValue('hidden', false, { shouldValidate: true })
+    }
+  }, [getValues, setValue, visibility])
   const agoraUuid = useMemo(() => {
     return scopes.data?.list.find((x) => x.code === selectedScope)?.attributes?.agoras?.[0]?.uuid ?? null
   }, [selectedScope, scopes.data])
@@ -354,6 +361,7 @@ const useEventFormData = ({ edit }: EventFormProps) => {
     scopeOptions,
     catOptions,
     mode: mode ?? (isAgoraScope ? 'online' : 'meeting'),
+    visibility: visibility ?? defaultVisibilityForScope,
     visibilityOptions,
     navigation,
     editMode,


### PR DESCRIPTION
## Description

Garantit que lorsqu’un événement est en visibilité invitation, l’option hidden est automatiquement remise à false et verrouillée dans le formulaire (mobile et desktop) pour éviter tout état incohérent.

## Type de changement

- [ ] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)
