### PR TITLE
clean(base): remove react-native-skia dependency

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,15 +11,6 @@
 
     "headers": [
       {
-        "source": "/canvaskit.wasm",
-        "headers": [
-          {
-            "key": "Content-Type",
-            "value": "application/wasm"
-          }
-        ]
-      },
-      {
         "source": "/.well-known/apple-app-site-association",
         "headers": [
           {

--- a/index.web.tsx
+++ b/index.web.tsx
@@ -1,11 +1,1 @@
-import '@expo/metro-runtime'
-import { LoadSkiaWeb } from '@shopify/react-native-skia/lib/module/web'
-import { version } from 'canvaskit-wasm/package.json'
-import { App } from 'expo-router/build/qualified-entry'
-import { renderRootComponent } from 'expo-router/build/renderRootComponent'
-
-LoadSkiaWeb({
-  locateFile: (file) => `https://cdn.jsdelivr.net/npm/canvaskit-wasm@${version}/bin/full/${file}`,
-}).then(async () => {
-  renderRootComponent(App)
-})
+import 'expo-router/entry'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@react-native-firebase/messaging": "^23.2.1",
     "@rnmapbox/maps": "~10.3.1",
     "@sentry/react-native": "~7.11.0",
-    "@shopify/react-native-skia": "2.4.18",
     "@tamagui/babel-plugin": "^1.144",
     "@tamagui/config": "^1.144",
     "@tamagui/lucide-icons": "^1.144",

--- a/src/components/Skeleton/CardSkeleton.tsx
+++ b/src/components/Skeleton/CardSkeleton.tsx
@@ -1,7 +1,5 @@
 import React, { ComponentProps, ComponentPropsWithoutRef } from 'react'
-import { useDerivedValue, useSharedValue, withRepeat, withTiming } from 'react-native-reanimated'
 import Chip from '@/components/Chip/Chip'
-import { Canvas, LinearGradient, Rect, vec } from '@shopify/react-native-skia'
 import { Circle, Separator, Square, Stack, StackProps, styled, Card as TCard, withStaticProperties, XStack, YStack } from 'tamagui'
 import { ButtonFrameStyled } from '../Button'
 
@@ -16,32 +14,8 @@ const CardFrame = styled(YStack, {
 
 export type SkeCardFrameProps = ComponentProps<typeof TCard>
 const SkeCardFrame = ({ children, ...props }: SkeCardFrameProps) => {
-  const [{ height, width }, setX] = React.useState<{ height: number; width: number }>({ height: 0, width: 0 })
-
-  const sharedWidth = useSharedValue(0)
-  const vectorStart = useDerivedValue(() => vec(sharedWidth.value, 0))
-  const vectorEnd = useDerivedValue(() => vec(sharedWidth.value + width, 0))
-
   return (
-    <CardFrame
-      {...props}
-      overflow="hidden"
-      position="relative"
-      onLayout={(e) => {
-        setX(e.nativeEvent.layout)
-        sharedWidth.value = -e.nativeEvent.layout.width
-        sharedWidth.value = withRepeat(withTiming(e.nativeEvent.layout.width, { duration: 1000 }), -1, true)
-      }}
-    >
-      <YStack gap="$medium" style={{ flex: 1, position: 'absolute', zIndex: 10, width, height }}>
-        {height > 0 && width > 0 && (
-          <Canvas style={{ flex: 1, position: 'absolute', zIndex: 10, width, height }}>
-            <Rect x={0} y={0} width={width} height={height}>
-              <LinearGradient start={vectorStart} end={vectorEnd} colors={['white', 'rgba(255, 255, 255, 0)', 'rgba(255, 255, 255, 0)', 'white']} />
-            </Rect>
-          </Canvas>
-        )}
-      </YStack>
+    <CardFrame {...props} overflow="hidden">
       <YStack gap="$medium">{children}</YStack>
     </CardFrame>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -6341,27 +6341,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/react-native-skia@npm:2.4.18":
-  version: 2.4.18
-  resolution: "@shopify/react-native-skia@npm:2.4.18"
-  dependencies:
-    canvaskit-wasm: "npm:0.40.0"
-    react-reconciler: "npm:0.31.0"
-  peerDependencies:
-    react: ">=19.0"
-    react-native: ">=0.78"
-    react-native-reanimated: ">=3.19.1"
-  peerDependenciesMeta:
-    react-native:
-      optional: true
-    react-native-reanimated:
-      optional: true
-  bin:
-    setup-skia-web: scripts/setup-canvaskit.js
-  checksum: 10c0/24741a121c0bc3b4c3a321adb89ddcdb3add8cb66334b4a62510b2d11f377e086a1a2a8e3aac2737b9bf4eeb2716a1e026d540e47f1fcaed907030bfc7ee5972
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.27.8":
   version: 0.27.10
   resolution: "@sinclair/typebox@npm:0.27.10"
@@ -11630,13 +11609,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webgpu/types@npm:0.1.21":
-  version: 0.1.21
-  resolution: "@webgpu/types@npm:0.1.21"
-  checksum: 10c0/74de9683b70064aeadcdd31381747650b323e7e2183fb38f90a35f1a79f80ad267c0a2ee5010c264befb3d31ad213dbdffa04897e2808f6b04feff8d66bc53e0
-  languageName: node
-  linkType: hard
-
 "@xmldom/xmldom@npm:^0.8.8":
   version: 0.8.13
   resolution: "@xmldom/xmldom@npm:0.8.13"
@@ -13050,15 +13022,6 @@ __metadata:
   version: 1.0.30001775
   resolution: "caniuse-lite@npm:1.0.30001775"
   checksum: 10c0/96e59a83abd171c729db80a93d7a50becebc145102e3c2d2ea4b3749385cae1e6e09155bada486f662fa070009989d043c4c60f1ee64a19eb50139c7e6dbe574
-  languageName: node
-  linkType: hard
-
-"canvaskit-wasm@npm:0.40.0":
-  version: 0.40.0
-  resolution: "canvaskit-wasm@npm:0.40.0"
-  dependencies:
-    "@webgpu/types": "npm:0.1.21"
-  checksum: 10c0/dde817c0ef979a67afad4ac3adf31c03133af2592efec17f715a98508fdf801104fbf05af29723fb39b4d8b2798ce5306bb3cb5c062209d9d90a750430f3361d
   languageName: node
   linkType: hard
 
@@ -23341,17 +23304,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-reconciler@npm:0.31.0":
-  version: 0.31.0
-  resolution: "react-reconciler@npm:0.31.0"
-  dependencies:
-    scheduler: "npm:^0.25.0"
-  peerDependencies:
-    react: ^19.0.0
-  checksum: 10c0/97920e1866c7206e200c3920c133c2e85f62a3c54fd9bc4b83c10c558d83d98eb378caab4fe37498e0cc1b1b2665d898627f2ae2537b29c8ab295ec8abc0c580
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.14.0, react-refresh@npm:^0.14.2":
   version: 0.14.2
   resolution: "react-refresh@npm:0.14.2"
@@ -24061,13 +24013,6 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.25.0":
-  version: 0.25.0
-  resolution: "scheduler@npm:0.25.0"
-  checksum: 10c0/a4bb1da406b613ce72c1299db43759526058fdcc413999c3c3e0db8956df7633acf395cb20eb2303b6a65d658d66b6585d344460abaee8080b4aa931f10eaafe
   languageName: node
   linkType: hard
 
@@ -26452,7 +26397,6 @@ __metadata:
     "@react-native-firebase/messaging": "npm:^23.2.1"
     "@rnmapbox/maps": "npm:~10.3.1"
     "@sentry/react-native": "npm:~7.11.0"
-    "@shopify/react-native-skia": "npm:2.4.18"
     "@storybook/addon-ondevice-actions": "npm:^7.6.16"
     "@storybook/addon-ondevice-controls": "npm:^7.6.16"
     "@storybook/react-native": "npm:^7.6.16"


### PR DESCRIPTION
## Description

Suppression de @shopify/react-native-skia, utilisé uniquement pour l’effet shimmer des skeletons, au profit de placeholders statiques afin d’alléger le bundle natif et le chargement web (CanvasKit)

## Type de changement

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [x] 🔧 Chore (dépendances, outillage)