### PR TITLE
feat(event): preselect action and event category on create

### DIFF
--- a/src/components/ModalOrPageBase/ModalOrPageBase.tsx
+++ b/src/components/ModalOrPageBase/ModalOrPageBase.tsx
@@ -53,18 +53,20 @@ export default function ModalOrPageBase({
   if (isModal) {
     return (
       <Modal animationType={'fade'} transparent visible={!!open}>
-        <Pressable style={styles.centeredView} onPress={(event) => event.target == event.currentTarget && onClose?.()}>
+        <View style={styles.centeredView}>
           <ScrollView contentContainerStyle={styles.scrollContainer} bounces={false} showsVerticalScrollIndicator={false}>
-            <View style={styles.modalView}>
-              {modalContent}
-              {shouldDisplayCloseButton ? (
-                <TouchableOpacity style={{ position: 'absolute', top: 0, right: 0, padding: 14 }} onPress={onClose}>
-                  <X />
-                </TouchableOpacity>
-              ) : null}
-            </View>
+            <Pressable style={styles.backdrop} onPress={(event) => event.target === event.currentTarget && onClose?.()}>
+              <View style={styles.modalView}>
+                {modalContent}
+                {shouldDisplayCloseButton ? (
+                  <TouchableOpacity style={{ position: 'absolute', top: 0, right: 0, padding: 14 }} onPress={onClose}>
+                    <X />
+                  </TouchableOpacity>
+                ) : null}
+              </View>
+            </Pressable>
           </ScrollView>
-        </Pressable>
+        </View>
       </Modal>
     )
   }
@@ -124,9 +126,13 @@ const styles = StyleSheet.create({
   },
   centeredView: {
     flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  backdrop: {
+    flexGrow: 1,
+    width: '100%',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'rgba(0,0,0,0.5)',
     cursor: 'pointer',
   },
   modalView: {
@@ -154,7 +160,5 @@ const styles = StyleSheet.create({
   },
   scrollContainer: {
     flexGrow: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 })

--- a/src/features_next/actions/pages/create-edit/components/ActionTypeSelector.tsx
+++ b/src/features_next/actions/pages/create-edit/components/ActionTypeSelector.tsx
@@ -5,19 +5,32 @@ import Text from '@/components/base/Text'
 
 import type { IconComponent } from '@/models/common.model'
 
+export type CategoryChipTheme = 'green' | 'blue'
+
+const chipThemeStyles: Record<
+  CategoryChipTheme,
+  { selectedBg: string; unselectedBg: string; color: string; selectedColor: string }
+> = {
+  green: { selectedBg: '$green5', unselectedBg: '$green1', color: '$green7', selectedColor: '$white1' },
+  blue: { selectedBg: '$blue5', unselectedBg: '$blue1', color: '$blue7', selectedColor: '$white1' },
+}
+
 type ActionTypeSelectorProps = {
   label: string
   Icon?: IconComponent
   selected: boolean
+  theme?: CategoryChipTheme
   onPress: () => void
 }
 
-export default function ActionTypeSelector({ Icon, ...props }: ActionTypeSelectorProps) {
+export default function ActionTypeSelector({ Icon, theme = 'green', ...props }: ActionTypeSelectorProps) {
+  const styles = chipThemeStyles[theme]
+
   return (
     <TouchableOpacity onPress={props.onPress}>
-      <XStack bg={props.selected ? '$green5' : '$green1'} px={16} py={10} borderRadius={99} gap="$small">
-        {Icon ? <Icon size={16} color={props.selected ? '$white1' : '$green7'} /> : null}
-        <Text fontSize={14} semibold color={props.selected ? '$white1' : '$green7'}>
+      <XStack bg={props.selected ? styles.selectedBg : styles.unselectedBg} px={16} py={10} borderRadius={99} gap="$small">
+        {Icon ? <Icon size={16} color={props.selected ? styles.selectedColor : styles.color} /> : null}
+        <Text fontSize={14} semibold color={props.selected ? styles.selectedColor : styles.color}>
           {props.label}
         </Text>
       </XStack>

--- a/src/features_next/actions/pages/create-edit/helpers/context.tsx
+++ b/src/features_next/actions/pages/create-edit/helpers/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useRef } from 'react'
-import { type Href, useRouter } from 'expo-router'
+import { type Href, useLocalSearchParams, useRouter } from 'expo-router'
 import { addHours } from 'date-fns'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { type Control, type FieldPath, useForm } from 'react-hook-form'
@@ -40,16 +40,21 @@ export function useActionFormContext() {
   return ctx
 }
 
+const isActionType = (value: string | undefined): value is ActionType =>
+  value != null && (Object.values(ActionType) as string[]).includes(value)
+
 export function ActionFormContextProvider({ edit, children }: ActionFormProps & { children: React.ReactNode }) {
   const router = useRouter()
+  const { type: typeParam } = useLocalSearchParams<{ type?: string }>()
   const cancelModalRef = useRef<React.ComponentRef<typeof VoxSimpleModal>>(null)
+  const initialType = !edit && isActionType(typeParam) ? typeParam : ActionType.PAP
 
   const { control, handleSubmit, reset, setError } = useForm<ActionFormValues>({
     resolver: zodResolver(actionFormSchema),
     defaultValues: edit
       ? mapRestActionFullToFormDefaults(edit)
       : {
-          type: ActionType.PAP,
+          type: initialType,
           date: addHours(new Date(), 1),
           post_address: { address: '', postal_code: '', city_name: '', country: '' },
           description: '',

--- a/src/features_next/events/pages/create-edit/helpers/context.tsx
+++ b/src/features_next/events/pages/create-edit/helpers/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react'
-import { router, useNavigation } from 'expo-router'
+import { router, useLocalSearchParams, useNavigation } from 'expo-router'
 import { Sparkle } from '@tamagui/lucide-icons'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { addHours, addMinutes, formatISO, isAfter, isBefore, isEqual, isPast, isValid, setMilliseconds, setMinutes, setSeconds, subHours } from 'date-fns'
@@ -72,6 +72,7 @@ const roundMinutesToNextDecimal = (date: Date) => {
   }
 }
 const useEventFormData = ({ edit }: EventFormProps) => {
+  const { category: categoryParam } = useLocalSearchParams<{ category?: string }>()
   const scopes = useGetExecutiveScopes()
   const scopeOptions = useMemo(() => scopes.data?.list?.filter((x) => x.features.includes(FEATURES.EVENTS)).map(getFormatedScope) ?? [], [scopes.data])
   const canCreateAsCadre = scopes.hasFeature(FEATURES.EVENTS)
@@ -106,12 +107,22 @@ const useEventFormData = ({ edit }: EventFormProps) => {
   /** Portée Agora : événements toujours « en ligne » (produit). */
   const defaultModeForScope = String(initialScopeCode).startsWith('agora_') ? 'online' : (edit?.mode ?? 'meeting')
 
+  const initialCategorySlug = useMemo(() => {
+    if (edit?.category?.slug) {
+      return edit.category.slug
+    }
+    if (categoryParam && baseCatOptions.some((option) => option.value === categoryParam)) {
+      return categoryParam
+    }
+    return ''
+  }, [baseCatOptions, categoryParam, edit?.category?.slug])
+
   const defaultValues = {
     isPastEvent,
     scope: initialScopeCode,
     name: edit?.name ?? '',
     image: edit?.image,
-    category: edit?.category?.slug ?? '',
+    category: initialCategorySlug,
     description: {
       pure: edit ? '12345678910' : '',
       json: edit?.json_description ?? '',

--- a/src/features_next/events/pages/hub/components/EventsHubDesktop.tsx
+++ b/src/features_next/events/pages/hub/components/EventsHubDesktop.tsx
@@ -6,9 +6,10 @@ import HubEventFeed from './HubEventFeed'
 export type EventsHubDesktopProps = {
   mapLayer: ReactNode
   feedSuspenseFallback: ReactNode
+  onOpenOrganizeModal: () => void
 }
 
-export function EventsHubDesktop({ mapLayer, feedSuspenseFallback }: EventsHubDesktopProps) {
+export function EventsHubDesktop({ mapLayer, feedSuspenseFallback, onOpenOrganizeModal }: EventsHubDesktopProps) {
   return (
     <>
       <YStack flex={1} position="relative">
@@ -18,7 +19,7 @@ export function EventsHubDesktop({ mapLayer, feedSuspenseFallback }: EventsHubDe
       </YStack>
       <YStack flex={1} flexShrink={0} minHeight={0} maxWidth={390} width="100%">
         <Suspense fallback={feedSuspenseFallback}>
-          <HubEventFeed />
+          <HubEventFeed onOpenOrganizeModal={onOpenOrganizeModal} />
         </Suspense>
       </YStack>
     </>

--- a/src/features_next/events/pages/hub/components/EventsHubMobile.tsx
+++ b/src/features_next/events/pages/hub/components/EventsHubMobile.tsx
@@ -7,13 +7,18 @@ export type EventsHubMobileProps = {
   embeddedMapHeader: ReactNode
   tabBarSafeBottom: number
   feedSuspenseFallback: ReactNode
+  onOpenOrganizeModal: () => void
 }
 
-export function EventsHubMobile({ embeddedMapHeader, tabBarSafeBottom, feedSuspenseFallback }: EventsHubMobileProps) {
+export function EventsHubMobile({ embeddedMapHeader, tabBarSafeBottom, feedSuspenseFallback, onOpenOrganizeModal }: EventsHubMobileProps) {
   return (
     <YStack flex={1} width="100%" minHeight={0}>
       <Suspense fallback={feedSuspenseFallback}>
-        <HubEventFeed embeddedMapHeader={embeddedMapHeader} listContentInsetBottom={tabBarSafeBottom} />
+        <HubEventFeed
+          embeddedMapHeader={embeddedMapHeader}
+          listContentInsetBottom={tabBarSafeBottom}
+          onOpenOrganizeModal={onOpenOrganizeModal}
+        />
       </Suspense>
     </YStack>
   )

--- a/src/features_next/events/pages/hub/components/HubEventFeed.tsx
+++ b/src/features_next/events/pages/hub/components/HubEventFeed.tsx
@@ -5,7 +5,6 @@ import type { ReactNode } from 'react'
 import { memo, useCallback, useMemo, useRef } from 'react'
 import { FlatList, Platform } from 'react-native'
 import { useScrollToTop } from '@react-navigation/native'
-import type { Href } from 'expo-router'
 import { getToken, Spinner, XStack, YStack } from 'tamagui'
 import { Calendar, CalendarCheck2, ChevronRight, ClipboardCheck, DoorOpen, Zap } from '@tamagui/lucide-icons'
 
@@ -29,17 +28,14 @@ const mapHubItemsToFeedRows = (items: RestHubItem[]): HubFeedRowType[] => items.
 const getFeedRowKey = (row: HubFeedRowType): string =>
   row.type === 'event' ? row.event.uuid : (row.payload.id ?? `action-${row.payload.date.start.toISOString()}`)
 
-const CREER_EVENEMENT_HREF = '/evenements/creer' as const satisfies Href
-const CREER_ACTION_HREF = '/actions/creer' as const satisfies Href
-
-const HubOrganizePromptCards = memo(function HubOrganizePromptCards() {
+const HubOrganizePromptCards = memo(function HubOrganizePromptCards({ onOpenOrganizeModal }: { onOpenOrganizeModal: () => void }) {
   return (
     <XStack gap="$medium" px="$medium">
       <YStack width="50%" flex={1}>
-        <ButtonCard theme="green" icon={Zap} label="Organisez une action près de chez vous" href={CREER_ACTION_HREF} />
+        <ButtonCard theme="green" icon={Zap} label="Organisez une action près de chez vous" onPress={onOpenOrganizeModal} />
       </YStack>
       <YStack width="50%" flex={1}>
-        <ButtonCard theme="blue" icon={Calendar} label="Organisez un événement" href={CREER_EVENEMENT_HREF} />
+        <ButtonCard theme="blue" icon={Calendar} label="Organisez un événement" onPress={onOpenOrganizeModal} />
       </YStack>
     </XStack>
   )
@@ -73,10 +69,11 @@ type HubEventFeedProps = {
   embeddedMapHeader?: ReactNode
   /** Marge sous le contenu pour la tab bar + safe area. */
   listContentInsetBottom?: number
+  onOpenOrganizeModal: () => void
 }
 
 const HubEventFeed = (props: HubEventFeedProps) => {
-  const { embeddedMapHeader, listContentInsetBottom = 0 } = props
+  const { embeddedMapHeader, listContentInsetBottom = 0, onOpenOrganizeModal } = props
   const { session, isAuth } = useSession()
   const { data: userData } = useGetProfil({ enabled: Boolean(session) })
   const filtersReady = !isAuth || userData !== undefined
@@ -103,7 +100,7 @@ const HubEventFeed = (props: HubEventFeedProps) => {
       <QueryBoundary>
         <PinnedItemBanner small />
       </QueryBoundary>
-      <HubOrganizePromptCards />
+      <HubOrganizePromptCards onOpenOrganizeModal={onOpenOrganizeModal} />
       <YStack px="$medium" gap="$medium">
         <XStack gap="$small">
           <CalendarCheck2 size={16} color="$blue5" />

--- a/src/features_next/events/pages/hub/components/HubOrganizeCategoryModal.tsx
+++ b/src/features_next/events/pages/hub/components/HubOrganizeCategoryModal.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Dimensions } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useRouter, type Href } from 'expo-router'
+import { useMedia, XStack, YStack } from 'tamagui'
+import { Calendar, Info, X } from '@tamagui/lucide-icons'
+
+import Text from '@/components/base/Text'
+import { VoxButton } from '@/components/Button'
+import { VoxHeader } from '@/components/Header/Header'
+import { MessageCard } from '@/components/MessageCard/MessageCard'
+import ModalOrPageBase from '@/components/ModalOrPageBase/ModalOrPageBase'
+import ActionTypeSelector from '@/features_next/actions/pages/create-edit/components/ActionTypeSelector'
+
+import { ActionType, ActionTypeIcon, ReadableActionType } from '@/services/actions/schema'
+import { useSuspenseGetCategories } from '@/services/events/hook'
+
+type HubOrganizeCategoryModalProps = {
+  open: boolean
+  onClose: () => void
+}
+
+type OrganizeSelection = { itemType: 'action'; value: ActionType } | { itemType: 'event'; value: string }
+
+const CREER_ACTION_HREF = '/actions/creer' as const satisfies Href
+const CREER_EVENEMENT_HREF = '/evenements/creer' as const satisfies Href
+
+const windowSize = Dimensions.get('window')
+
+export function HubOrganizeCategoryModal({ open, onClose }: HubOrganizeCategoryModalProps) {
+  const router = useRouter()
+  const media = useMedia()
+  const { data: categories } = useSuspenseGetCategories()
+  const [selection, setSelection] = useState<OrganizeSelection | null>(null)
+
+  const canContinue = selection != null
+
+  const handleContinue = useCallback(() => {
+    if (!selection) return
+    onClose()
+    if (selection.itemType === 'action') {
+      router.push({ pathname: CREER_ACTION_HREF, params: { type: selection.value } })
+      return
+    }
+    router.push({ pathname: CREER_EVENEMENT_HREF, params: { category: selection.value } })
+  }, [onClose, router, selection])
+
+  const mobileHeader = useMemo(
+    () => (
+      <VoxHeader>
+        <XStack alignItems="center" flex={1} width="100%">
+          <XStack alignContent="flex-start">
+            <VoxButton size="lg" variant="text" theme="orange" onPress={onClose}>
+              Annuler
+            </VoxButton>
+          </XStack>
+          <XStack flexGrow={1} justifyContent="center">
+            <VoxHeader.Title>Organiser</VoxHeader.Title>
+          </XStack>
+          <XStack>
+            <VoxButton size="md" theme="purple" disabled={!canContinue} onPress={handleContinue}>
+              Suivant
+            </VoxButton>
+          </XStack>
+        </XStack>
+      </VoxHeader>
+    ),
+    [canContinue, handleContinue, onClose],
+  )
+
+  const desktopHeader = (
+    <XStack width="100%" height={56} px="$medium" alignItems="center" justifyContent="center" borderBottomWidth={1} borderColor="$textOutline">
+      <VoxHeader.Title>Organiser</VoxHeader.Title>
+      <YStack position="absolute" right={0} onPress={onClose} padding="$large" cursor="pointer">
+        <X size={24} color="$textPrimary" />
+      </YStack>
+    </XStack>
+  )
+
+  const maxHeight = media.sm ? windowSize.height - 56 : windowSize.height * 0.8
+  const width = media.gtMd ? 892 : '100%'
+
+  return (
+    <ModalOrPageBase open={open} onClose={onClose} header={mobileHeader}>
+      <SafeAreaView style={{ flex: 1 }} edges={media.gtMd ? [] : ['bottom']}>
+        <YStack flex={1} width={width} maxHeight={media.gtMd ? maxHeight : undefined} bg="$white1">
+          {media.gtMd ? desktopHeader : null}
+          <MessageCard theme="gray" iconLeft={Info}>
+            Créez vos propres événements et actions militantes pour mobiliser autour de vous et faire vivre le terrain.
+          </MessageCard>
+          <YStack flex={1} px="$medium" py="$large" gap="$medium">
+            <Text.MD secondary semibold>
+              Que souhaitez vous organiser ?
+            </Text.MD>
+            <YStack gap="$small">
+              <XStack flexWrap="wrap" gap="$small">
+                {Object.values(ActionType).map((type) => (
+                  <ActionTypeSelector
+                    key={type}
+                    theme="green"
+                    label={ReadableActionType[type]}
+                    Icon={ActionTypeIcon[type]}
+                    selected={selection?.itemType === 'action' && selection.value === type}
+                    onPress={() => setSelection({ itemType: 'action', value: type })}
+                  />
+                ))}
+              </XStack>
+              <XStack flexWrap="wrap" gap="$small">
+                {categories.map((category) => (
+                  <ActionTypeSelector
+                    key={category.slug}
+                    theme="blue"
+                    label={category.name}
+                    Icon={Calendar}
+                    selected={selection?.itemType === 'event' && selection.value === category.slug}
+                    onPress={() => setSelection({ itemType: 'event', value: category.slug })}
+                  />
+                ))}
+              </XStack>
+            </YStack>
+          </YStack>
+          {media.gtMd ? (
+            <XStack width="100%" height={56} px="$medium" alignItems="center" justifyContent="flex-end">
+              <VoxButton size="md" theme="purple" disabled={!canContinue} onPress={handleContinue}>
+                Suivant
+              </VoxButton>
+            </XStack>
+          ) : null}
+        </YStack>
+      </SafeAreaView>
+    </ModalOrPageBase>
+  )
+}

--- a/src/features_next/events/pages/hub/index.tsx
+++ b/src/features_next/events/pages/hub/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { Spinner, useMedia, YStack } from 'tamagui'
@@ -14,6 +14,7 @@ import { useUserLocation } from '../map/hooks/useUserLocation'
 import { EventsHubDesktop } from './components/EventsHubDesktop'
 import { EventsHubMobile } from './components/EventsHubMobile'
 import { HubMapBlock } from './components/HubMapBlock'
+import { HubOrganizeCategoryModal } from './components/HubOrganizeCategoryModal'
 
 const EventsHubPage = () => {
   const router = useRouter()
@@ -21,6 +22,15 @@ const EventsHubPage = () => {
   const { coords, isLocating, requestLocation } = useUserLocation()
 
   const [sortAround, setSortAround] = useState<{ lat: number; lng: number } | null>(null)
+  const [organizeModalOpen, setOrganizeModalOpen] = useState(false)
+
+  const handleOpenOrganizeModal = useCallback(() => {
+    setOrganizeModalOpen(true)
+  }, [])
+
+  const handleCloseOrganizeModal = useCallback(() => {
+    setOrganizeModalOpen(false)
+  }, [])
   const media = useMedia()
   const insets = useSafeAreaInsets()
   const cameraPadding = useMemo(
@@ -102,21 +112,35 @@ const EventsHubPage = () => {
     </YStack>
   )
 
+  const organizeModal = organizeModalOpen ? (
+    <Suspense fallback={null}>
+      <HubOrganizeCategoryModal open onClose={handleCloseOrganizeModal} />
+    </Suspense>
+  ) : null
+
   if (!media.gtSm) {
     return (
-      <EventsHubMobile
-        embeddedMapHeader={<HubMapBlock {...mapBlockCommonProps} variant="embedded" />}
-        tabBarSafeBottom={tabBarSafeBottom}
-        feedSuspenseFallback={feedSuspenseFallback}
-      />
+      <>
+        <EventsHubMobile
+          embeddedMapHeader={<HubMapBlock {...mapBlockCommonProps} variant="embedded" />}
+          tabBarSafeBottom={tabBarSafeBottom}
+          feedSuspenseFallback={feedSuspenseFallback}
+          onOpenOrganizeModal={handleOpenOrganizeModal}
+        />
+        {organizeModal}
+      </>
     )
   }
 
   return (
-    <EventsHubDesktop
-      mapLayer={<HubMapBlock {...mapBlockCommonProps} variant="fullscreen" promoLeadingAccessory={<SideBarArea state="militant" />} />}
-      feedSuspenseFallback={feedSuspenseFallback}
-    />
+    <>
+      <EventsHubDesktop
+        mapLayer={<HubMapBlock {...mapBlockCommonProps} variant="fullscreen" promoLeadingAccessory={<SideBarArea state="militant" />} />}
+        feedSuspenseFallback={feedSuspenseFallback}
+        onOpenOrganizeModal={handleOpenOrganizeModal}
+      />
+      {organizeModal}
+    </>
   )
 }
 


### PR DESCRIPTION
## Description

Ajoute une modale « Organiser » sur le hub événements pour choisir le type d’action ou la catégorie d’événement avant la création, préremplit les formulaires via les query params, et corrige la fermeture au clic sur le fond des modales desktop dans ModalOrPageBase

## Type de changement

- [x] 🐛 Bug fix
- [x] ✨ Nouvelle fonctionnalité
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation
- [ ] 🔧 Chore (dépendances, outillage)
